### PR TITLE
1.4.1

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -2,49 +2,35 @@
 
 ## Bug Fixes
 
-### Error messages now include `RequestorType` when callbacks throw
-
-**Fixed**: When `DependencyWaitInfo.ResultCallback` threw an exception in generated IScope code, the error message did not include the `RequestorType`. All catch blocks in generated scope code now report the requestor type through `ErrorReporter.ReportWaiterCallbackException` and `ErrorReporter.ReportResolveDependencyCallbackException`.
-
----
+- Fixed: callback exception error messages now include `RequestorType`
+- Fixed: NuGet package could contain stale DLLs due to incorrect path references in `GodotSharpDI.csproj`
 
 ## Breaking Changes
 
 ### `ErrorReporter` API refactored
 
-- `Output` and `ErrorOutput` changed from `public` to `internal`
-- Default output changed from `Debug.WriteLine` to `GD.PushWarning` / `GD.PrintErr`
-- All `Report*` methods now accept `Exception` instead of `string exMsg`
-- `BuildServiceNotFoundMessage` / `BuildServiceErrorMessage` replaced by `ReportServiceNotFound` / `ReportServiceError` (void, output directly)
-- New methods: `ReportParentScopeNotFound`, `ReportWaiterCallbackException`, `ReportResolveDependencyCallbackException`, `ReportError`, `ReportWarning`
+- Removed `Output` / `ErrorOutput` static fields
+- Removed `ReportWarning` method
+- All `Report*` methods accept `Exception` instead of `string exMsg`, and `Action<string> errorOutput` as the last parameter
+- `BuildServiceNotFoundMessage` / `BuildServiceErrorMessage` replaced by `ReportServiceNotFound` / `ReportServiceError`
+- New methods: `ReportParentScopeNotFound`, `ReportWaiterCallbackException`, `ReportResolveDependencyCallbackException`, `ReportError`
 
-### `AsyncProviderRunner.Run` / `WaitForCoordinator.Register` parameter removed
+### Runtime class method signatures updated
 
-The `reportError` parameter has been removed from both methods. Error reporting is now handled internally through `ErrorReporter`.
+The following runtime classes now require an `Action<string> errorOutput` parameter for error reporting (previously used `ErrorReporter` static fields):
 
-**Migration**: Remove the `reportError` argument from all call sites. Generated code is updated automatically.
+- `AsyncProviderRunner.Run`
+- `SyncProviderRunner.Run`
+- `InjectionExecutor.Execute`
+- `WaitForCoordinator.Register`
+- `DeadlockDetector.TrackAndDetect`
 
-### Target framework upgraded to `net8.0`
-
-`GodotSharpDI.Runtime` and `GodotSharpDI` now target `net8.0` instead of `netstandard2.0`. This allows direct use of Godot APIs (`GD.PushWarning`, `GD.PrintErr`) without delegate injection.
-
----
+**Migration**: If you call these methods directly, add a `GD.PrintErr` (or equivalent) delegate as the `errorOutput` parameter. Generated code is updated automatically.
 
 ## Internal Improvements
 
-### Source generator error reporting centralized
-
-All `f.PrintError(...)` calls in generated scope code replaced with `ErrorReporter.Report*` methods. This ensures consistent error message formatting and includes structured context (type names, requestor, scope chain, dependency chain).
-
-### Removed `ErrorReporter` initialization from generated code
-
-`GenerateErrorReporterInit` has been removed from `NodeLifeCycleGenerator`. Since `ErrorReporter` now defaults to Godot's `GD.PushWarning` / `GD.PrintErr`, no runtime initialization is needed.
-
-### Test helper extraction
-
-- Extracted `ErrorReporterHelper` into `GodotSharpDI.Runtime.Tests/Helpers/` and `GodotSharpDI.SourceGenerator.Tests/Helpers/`
-- Provides `Capture()` (errors + warnings) and `CaptureErrors()` (errors only)
-- All test files now use the shared helper instead of inline capture patterns
+- Extracted `ErrorReporterHelper` test helper for capturing error output in tests
+- Cleaned up `nuget-build.bat` to properly clean all project outputs
 
 ---
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,3 +1,53 @@
+# v1.4.1
+
+## Bug Fixes
+
+### Error messages now include `RequestorType` when callbacks throw
+
+**Fixed**: When `DependencyWaitInfo.ResultCallback` threw an exception in generated IScope code, the error message did not include the `RequestorType`. All catch blocks in generated scope code now report the requestor type through `ErrorReporter.ReportWaiterCallbackException` and `ErrorReporter.ReportResolveDependencyCallbackException`.
+
+---
+
+## Breaking Changes
+
+### `ErrorReporter` API refactored
+
+- `Output` and `ErrorOutput` changed from `public` to `internal`
+- Default output changed from `Debug.WriteLine` to `GD.PushWarning` / `GD.PrintErr`
+- All `Report*` methods now accept `Exception` instead of `string exMsg`
+- `BuildServiceNotFoundMessage` / `BuildServiceErrorMessage` replaced by `ReportServiceNotFound` / `ReportServiceError` (void, output directly)
+- New methods: `ReportParentScopeNotFound`, `ReportWaiterCallbackException`, `ReportResolveDependencyCallbackException`, `ReportError`, `ReportWarning`
+
+### `AsyncProviderRunner.Run` / `WaitForCoordinator.Register` parameter removed
+
+The `reportError` parameter has been removed from both methods. Error reporting is now handled internally through `ErrorReporter`.
+
+**Migration**: Remove the `reportError` argument from all call sites. Generated code is updated automatically.
+
+### Target framework upgraded to `net8.0`
+
+`GodotSharpDI.Runtime` and `GodotSharpDI` now target `net8.0` instead of `netstandard2.0`. This allows direct use of Godot APIs (`GD.PushWarning`, `GD.PrintErr`) without delegate injection.
+
+---
+
+## Internal Improvements
+
+### Source generator error reporting centralized
+
+All `f.PrintError(...)` calls in generated scope code replaced with `ErrorReporter.Report*` methods. This ensures consistent error message formatting and includes structured context (type names, requestor, scope chain, dependency chain).
+
+### Removed `ErrorReporter` initialization from generated code
+
+`GenerateErrorReporterInit` has been removed from `NodeLifeCycleGenerator`. Since `ErrorReporter` now defaults to Godot's `GD.PushWarning` / `GD.PrintErr`, no runtime initialization is needed.
+
+### Test helper extraction
+
+- Extracted `ErrorReporterHelper` into `GodotSharpDI.Runtime.Tests/Helpers/` and `GodotSharpDI.SourceGenerator.Tests/Helpers/`
+- Provides `Capture()` (errors + warnings) and `CaptureErrors()` (errors only)
+- All test files now use the shared helper instead of inline capture patterns
+
+---
+
 # v1.4.0
 
 ## New Features

--- a/CHANGE_LOG.zh-CN.md
+++ b/CHANGE_LOG.zh-CN.md
@@ -2,49 +2,35 @@
 
 ## Bug 修复
 
-### 错误信息现在包含 `RequestorType`
-
-**修复**：当生成的 IScope 代码中 `DependencyWaitInfo.ResultCallback` 抛出异常时，错误信息未包含 `RequestorType`。现在生成的 Scope 代码中所有 catch 块均通过 `ErrorReporter.ReportWaiterCallbackException` 和 `ErrorReporter.ReportResolveDependencyCallbackException` 报告请求者类型。
-
----
+- 修复：回调异常的错误信息现在包含 `RequestorType`
+- 修复：NuGet 包可能包含旧 DLL，原因是 `GodotSharpDI.csproj` 中的路径引用不正确
 
 ## 破坏性变更
 
 ### `ErrorReporter` API 重构
 
-- `Output` 和 `ErrorOutput` 从 `public` 改为 `internal`
-- 默认输出从 `Debug.WriteLine` 改为 `GD.PushWarning` / `GD.PrintErr`
-- 所有 `Report*` 方法现在接受 `Exception` 而非 `string exMsg`
-- `BuildServiceNotFoundMessage` / `BuildServiceErrorMessage` 替换为 `ReportServiceNotFound` / `ReportServiceError`（直接输出，无返回值）
-- 新增方法：`ReportParentScopeNotFound`、`ReportWaiterCallbackException`、`ReportResolveDependencyCallbackException`、`ReportError`、`ReportWarning`
+- 移除 `Output` / `ErrorOutput` 静态字段
+- 移除 `ReportWarning` 方法
+- 所有 `Report*` 方法接受 `Exception` 而非 `string exMsg`，新增 `Action<string> errorOutput` 作为最后一个参数
+- `BuildServiceNotFoundMessage` / `BuildServiceErrorMessage` 替换为 `ReportServiceNotFound` / `ReportServiceError`
+- 新增方法：`ReportParentScopeNotFound`、`ReportWaiterCallbackException`、`ReportResolveDependencyCallbackException`、`ReportError`
 
-### `AsyncProviderRunner.Run` / `WaitForCoordinator.Register` 移除参数
+### 运行时类方法签名更新
 
-两个方法的 `reportError` 参数已移除，错误报告现通过 `ErrorReporter` 内部处理。
+以下运行时类现要求传入 `Action<string> errorOutput` 参数用于错误报告（此前使用 `ErrorReporter` 静态字段）：
 
-**迁移方式**：从所有调用处移除 `reportError` 参数。生成代码已自动更新。
+- `AsyncProviderRunner.Run`
+- `SyncProviderRunner.Run`
+- `InjectionExecutor.Execute`
+- `WaitForCoordinator.Register`
+- `DeadlockDetector.TrackAndDetect`
 
-### 目标框架升级至 `net8.0`
-
-`GodotSharpDI.Runtime` 和 `GodotSharpDI` 现目标框架为 `net8.0`（原为 `netstandard2.0`）。这使得可以直接使用 Godot API（`GD.PushWarning`、`GD.PrintErr`），无需委托注入。
-
----
+**迁移方式**：如直接调用这些方法，需添加 `GD.PrintErr`（或等效委托）作为 `errorOutput` 参数。生成代码已自动更新。
 
 ## 内部改进
 
-### 源生成器错误报告集中化
-
-生成的 Scope 代码中所有 `f.PrintError(...)` 调用替换为 `ErrorReporter.Report*` 方法，确保错误信息格式一致，并包含结构化上下文（类型名、请求者、作用域链、依赖链）。
-
-### 移除生成代码中的 `ErrorReporter` 初始化
-
-`NodeLifeCycleGenerator` 中的 `GenerateErrorReporterInit` 已移除。由于 `ErrorReporter` 现默认使用 Godot 的 `GD.PushWarning` / `GD.PrintErr`，运行时无需初始化。
-
-### 测试辅助类提取
-
-- 将 `ErrorReporterHelper` 提取至 `GodotSharpDI.Runtime.Tests/Helpers/` 和 `GodotSharpDI.SourceGenerator.Tests/Helpers/`
-- 提供 `Capture()`（错误 + 警告）和 `CaptureErrors()`（仅错误）方法
-- 所有测试文件现使用共享辅助类，替代内联捕获模式
+- 提取 `ErrorReporterHelper` 测试辅助类，用于在测试中捕获错误输出
+- 清理 `nuget-build.bat`，正确清理所有项目输出
 
 ---
 

--- a/CHANGE_LOG.zh-CN.md
+++ b/CHANGE_LOG.zh-CN.md
@@ -1,3 +1,53 @@
+# v1.4.1
+
+## Bug 修复
+
+### 错误信息现在包含 `RequestorType`
+
+**修复**：当生成的 IScope 代码中 `DependencyWaitInfo.ResultCallback` 抛出异常时，错误信息未包含 `RequestorType`。现在生成的 Scope 代码中所有 catch 块均通过 `ErrorReporter.ReportWaiterCallbackException` 和 `ErrorReporter.ReportResolveDependencyCallbackException` 报告请求者类型。
+
+---
+
+## 破坏性变更
+
+### `ErrorReporter` API 重构
+
+- `Output` 和 `ErrorOutput` 从 `public` 改为 `internal`
+- 默认输出从 `Debug.WriteLine` 改为 `GD.PushWarning` / `GD.PrintErr`
+- 所有 `Report*` 方法现在接受 `Exception` 而非 `string exMsg`
+- `BuildServiceNotFoundMessage` / `BuildServiceErrorMessage` 替换为 `ReportServiceNotFound` / `ReportServiceError`（直接输出，无返回值）
+- 新增方法：`ReportParentScopeNotFound`、`ReportWaiterCallbackException`、`ReportResolveDependencyCallbackException`、`ReportError`、`ReportWarning`
+
+### `AsyncProviderRunner.Run` / `WaitForCoordinator.Register` 移除参数
+
+两个方法的 `reportError` 参数已移除，错误报告现通过 `ErrorReporter` 内部处理。
+
+**迁移方式**：从所有调用处移除 `reportError` 参数。生成代码已自动更新。
+
+### 目标框架升级至 `net8.0`
+
+`GodotSharpDI.Runtime` 和 `GodotSharpDI` 现目标框架为 `net8.0`（原为 `netstandard2.0`）。这使得可以直接使用 Godot API（`GD.PushWarning`、`GD.PrintErr`），无需委托注入。
+
+---
+
+## 内部改进
+
+### 源生成器错误报告集中化
+
+生成的 Scope 代码中所有 `f.PrintError(...)` 调用替换为 `ErrorReporter.Report*` 方法，确保错误信息格式一致，并包含结构化上下文（类型名、请求者、作用域链、依赖链）。
+
+### 移除生成代码中的 `ErrorReporter` 初始化
+
+`NodeLifeCycleGenerator` 中的 `GenerateErrorReporterInit` 已移除。由于 `ErrorReporter` 现默认使用 Godot 的 `GD.PushWarning` / `GD.PrintErr`，运行时无需初始化。
+
+### 测试辅助类提取
+
+- 将 `ErrorReporterHelper` 提取至 `GodotSharpDI.Runtime.Tests/Helpers/` 和 `GodotSharpDI.SourceGenerator.Tests/Helpers/`
+- 提供 `Capture()`（错误 + 警告）和 `CaptureErrors()`（仅错误）方法
+- 所有测试文件现使用共享辅助类，替代内联捕获模式
+
+---
+
 # v1.4.0
 
 ## 新功能

--- a/GodotSharpDI.Runtime.Tests/AsyncProviderRunnerTests.cs
+++ b/GodotSharpDI.Runtime.Tests/AsyncProviderRunnerTests.cs
@@ -2,53 +2,41 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using GodotSharpDI.Runtime.Tests.Helpers;
 using Xunit;
 
 namespace GodotSharpDI.Runtime.Tests;
 
 public class AsyncProviderRunnerTests
 {
-    private static (List<string> errors, List<string> warnings, Action restore) CaptureErrorReporter()
-    {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () => { ErrorReporter.ErrorOutput = prevError; ErrorReporter.Output = prevOutput; });
-    }
-
     [Fact]
     public async Task Run_Success_InstanceProvidedViaDispatch()
     {
-        var (_, _, restore) = CaptureErrorReporter();
-        try
-        {
-            var instance = new object();
-            object? provided = null;
-            Action<Action>? capturedDispatch = null;
+        var instance = new object();
+        object? provided = null;
+        Action<Action>? capturedDispatch = null;
 
-            await AsyncProviderRunner.Run(
-                Task.FromResult(instance),
-                (inst, _) => provided = inst,
-                "TestProvider",
-                CancellationToken.None,
-                _ => { },
-                action => { capturedDispatch = a => action(); });
+        await AsyncProviderRunner.Run(
+            Task.FromResult(instance),
+            (inst, _) => provided = inst,
+            "TestProvider",
+            CancellationToken.None,
+            action =>
+            {
+                capturedDispatch = a => action();
+            }
+        );
 
-            // Simulate main-thread dispatch
-            Assert.NotNull(capturedDispatch);
-            capturedDispatch!(() => { });
-            Assert.Same(instance, provided);
-        }
-        finally { restore(); }
+        // Simulate main-thread dispatch
+        Assert.NotNull(capturedDispatch);
+        capturedDispatch!(() => { });
+        Assert.Same(instance, provided);
     }
 
     [Fact]
     public async Task Run_TaskThrows_ErrorReportedAndNullProvided()
     {
-        var (errors, _, restore) = CaptureErrorReporter();
+        var (errors, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             object? provided = null;
@@ -59,8 +47,11 @@ public class AsyncProviderRunnerTests
                 (inst, _) => provided = inst,
                 "TestProvider",
                 CancellationToken.None,
-                msg => ErrorReporter.ErrorOutput(msg),
-                action => { capturedDispatch = a => action(); });
+                action =>
+                {
+                    capturedDispatch = a => action();
+                }
+            );
 
             Assert.NotEmpty(errors);
             Assert.Contains("async broke", errors[0]);
@@ -76,7 +67,7 @@ public class AsyncProviderRunnerTests
     [Fact]
     public async Task Run_Cancelled_SilentExit()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             object? provided = null;
@@ -90,19 +81,22 @@ public class AsyncProviderRunnerTests
                 (inst, _) => provided = inst,
                 "TestProvider",
                 cts.Token,
-                _ => { },
-                _ => dispatchCalled = true);
+                _ => dispatchCalled = true
+            );
 
             Assert.Null(provided);
             Assert.False(dispatchCalled);
         }
-        finally { restore(); }
+        finally
+        {
+            restore();
+        }
     }
 
     [Fact]
     public async Task Run_CancelledAfterTask_CompletesButSkipsDispatch()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             object? provided = null;
@@ -122,19 +116,22 @@ public class AsyncProviderRunnerTests
                 (inst, _) => provided = inst,
                 "TestProvider",
                 cts.Token,
-                _ => { },
-                _ => dispatchCalled = true);
+                _ => dispatchCalled = true
+            );
 
             Assert.Null(provided);
             Assert.False(dispatchCalled);
         }
-        finally { restore(); }
+        finally
+        {
+            restore();
+        }
     }
 
     [Fact]
     public async Task Run_ProviderTypePassedToProvide()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             string? capturedType = null;
@@ -145,19 +142,25 @@ public class AsyncProviderRunnerTests
                 (_, pt) => capturedType = pt,
                 "MyHost",
                 CancellationToken.None,
-                _ => { },
-                action => { capturedDispatch = a => action(); });
+                action =>
+                {
+                    capturedDispatch = a => action();
+                }
+            );
 
             capturedDispatch!(() => { });
             Assert.Equal("MyHost", capturedType);
         }
-        finally { restore(); }
+        finally
+        {
+            restore();
+        }
     }
 
     [Fact]
     public async Task Run_DispatchThrowsOnCancelled_DoesNotProvide()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             object? provided = null;
@@ -171,11 +174,16 @@ public class AsyncProviderRunnerTests
                 (inst, _) => provided = inst,
                 "TestProvider",
                 cts.Token,
-                _ => { },
-                action => { /* Don't call action since cancelled */ });
+                action =>
+                { /* Don't call action since cancelled */
+                }
+            );
 
             Assert.Null(provided);
         }
-        finally { restore(); }
+        finally
+        {
+            restore();
+        }
     }
 }

--- a/GodotSharpDI.Runtime.Tests/AsyncProviderRunnerTests.cs
+++ b/GodotSharpDI.Runtime.Tests/AsyncProviderRunnerTests.cs
@@ -9,6 +9,8 @@ namespace GodotSharpDI.Runtime.Tests;
 
 public class AsyncProviderRunnerTests
 {
+    private static readonly Action<string> NoOp = _ => { };
+
     [Fact]
     public async Task Run_Success_InstanceProvidedViaDispatch()
     {
@@ -21,6 +23,7 @@ public class AsyncProviderRunnerTests
             (inst, _) => provided = inst,
             "TestProvider",
             CancellationToken.None,
+            NoOp,
             action =>
             {
                 capturedDispatch = a => action();
@@ -36,154 +39,124 @@ public class AsyncProviderRunnerTests
     [Fact]
     public async Task Run_TaskThrows_ErrorReportedAndNullProvided()
     {
-        var (errors, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            object? provided = null;
-            Action<Action>? capturedDispatch = null;
+        var errors = new List<string>();
+        var errorOutput = ErrorReporterHelper.CreateErrorCollector(errors);
+        object? provided = null;
+        Action<Action>? capturedDispatch = null;
 
-            await AsyncProviderRunner.Run<object>(
-                Task.FromException<object>(new InvalidOperationException("async broke")),
-                (inst, _) => provided = inst,
-                "TestProvider",
-                CancellationToken.None,
-                action =>
-                {
-                    capturedDispatch = a => action();
-                }
-            );
+        await AsyncProviderRunner.Run<object>(
+            Task.FromException<object>(new InvalidOperationException("async broke")),
+            (inst, _) => provided = inst,
+            "TestProvider",
+            CancellationToken.None,
+            errorOutput,
+            action =>
+            {
+                capturedDispatch = a => action();
+            }
+        );
 
-            Assert.NotEmpty(errors);
-            Assert.Contains("async broke", errors[0]);
+        Assert.NotEmpty(errors);
+        Assert.Contains("async broke", errors[0]);
 
-            // Simulate main-thread dispatch for the failure path
-            Assert.NotNull(capturedDispatch);
-            capturedDispatch!(() => { });
-            Assert.Null(provided);
-        }
-        finally { restore(); }
+        // Simulate main-thread dispatch for the failure path
+        Assert.NotNull(capturedDispatch);
+        capturedDispatch!(() => { });
+        Assert.Null(provided);
     }
 
     [Fact]
     public async Task Run_Cancelled_SilentExit()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            object? provided = null;
-            var dispatchCalled = false;
+        object? provided = null;
+        var dispatchCalled = false;
 
-            using var cts = new CancellationTokenSource();
-            cts.Cancel();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
 
-            await AsyncProviderRunner.Run(
-                Task.FromResult(new object()),
-                (inst, _) => provided = inst,
-                "TestProvider",
-                cts.Token,
-                _ => dispatchCalled = true
-            );
+        await AsyncProviderRunner.Run(
+            Task.FromResult(new object()),
+            (inst, _) => provided = inst,
+            "TestProvider",
+            cts.Token,
+            NoOp,
+            _ => dispatchCalled = true
+        );
 
-            Assert.Null(provided);
-            Assert.False(dispatchCalled);
-        }
-        finally
-        {
-            restore();
-        }
+        Assert.Null(provided);
+        Assert.False(dispatchCalled);
     }
 
     [Fact]
     public async Task Run_CancelledAfterTask_CompletesButSkipsDispatch()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            object? provided = null;
-            var dispatchCalled = false;
+        object? provided = null;
+        var dispatchCalled = false;
 
-            using var cts = new CancellationTokenSource();
+        using var cts = new CancellationTokenSource();
 
-            // Create a task that completes, then cancel before dispatch
-            var task = Task.FromResult(new object());
-            await task;
+        // Create a task that completes, then cancel before dispatch
+        var task = Task.FromResult(new object());
+        await task;
 
-            // Cancel before the runner processes the result
-            cts.Cancel();
+        // Cancel before the runner processes the result
+        cts.Cancel();
 
-            await AsyncProviderRunner.Run(
-                task,
-                (inst, _) => provided = inst,
-                "TestProvider",
-                cts.Token,
-                _ => dispatchCalled = true
-            );
+        await AsyncProviderRunner.Run(
+            task,
+            (inst, _) => provided = inst,
+            "TestProvider",
+            cts.Token,
+            NoOp,
+            _ => dispatchCalled = true
+        );
 
-            Assert.Null(provided);
-            Assert.False(dispatchCalled);
-        }
-        finally
-        {
-            restore();
-        }
+        Assert.Null(provided);
+        Assert.False(dispatchCalled);
     }
 
     [Fact]
     public async Task Run_ProviderTypePassedToProvide()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            string? capturedType = null;
-            Action<Action>? capturedDispatch = null;
+        string? capturedType = null;
+        Action<Action>? capturedDispatch = null;
 
-            await AsyncProviderRunner.Run(
-                Task.FromResult(new object()),
-                (_, pt) => capturedType = pt,
-                "MyHost",
-                CancellationToken.None,
-                action =>
-                {
-                    capturedDispatch = a => action();
-                }
-            );
+        await AsyncProviderRunner.Run(
+            Task.FromResult(new object()),
+            (_, pt) => capturedType = pt,
+            "MyHost",
+            CancellationToken.None,
+            NoOp,
+            action =>
+            {
+                capturedDispatch = a => action();
+            }
+        );
 
-            capturedDispatch!(() => { });
-            Assert.Equal("MyHost", capturedType);
-        }
-        finally
-        {
-            restore();
-        }
+        capturedDispatch!(() => { });
+        Assert.Equal("MyHost", capturedType);
     }
 
     [Fact]
     public async Task Run_DispatchThrowsOnCancelled_DoesNotProvide()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            object? provided = null;
+        object? provided = null;
 
-            using var cts = new CancellationTokenSource();
-            cts.Cancel();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
 
-            // Dispatch that throws when cancelled — should not propagate
-            await AsyncProviderRunner.Run(
-                Task.FromResult(new object()),
-                (inst, _) => provided = inst,
-                "TestProvider",
-                cts.Token,
-                action =>
-                { /* Don't call action since cancelled */
-                }
-            );
+        // Dispatch that throws when cancelled — should not propagate
+        await AsyncProviderRunner.Run(
+            Task.FromResult(new object()),
+            (inst, _) => provided = inst,
+            "TestProvider",
+            cts.Token,
+            NoOp,
+            action =>
+            { /* Don't call action since cancelled */
+            }
+        );
 
-            Assert.Null(provided);
-        }
-        finally
-        {
-            restore();
-        }
+        Assert.Null(provided);
     }
 }

--- a/GodotSharpDI.Runtime.Tests/DeadlockDetectorTests.cs
+++ b/GodotSharpDI.Runtime.Tests/DeadlockDetectorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GodotSharpDI.Runtime.Tests.Helpers;
 using Xunit;
 
 namespace GodotSharpDI.Runtime.Tests;
@@ -8,27 +9,22 @@ public class DeadlockDetectorTests
 {
     private static (DeadlockDetector detector, List<string> errors, Action restore) CreateDetector()
     {
-        var errors = new List<string>();
-        var detector = new DeadlockDetector();
-        var prev = ErrorReporter.ErrorOutput;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        return (detector, errors, () => ErrorReporter.ErrorOutput = prev);
+        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
+        return (new DeadlockDetector(), errors, restore);
     }
 
     [Fact]
-    public void ErrorOutput_CallbackWorks()
+    public void ReportError_CapturesOutput()
     {
-        var prev = ErrorReporter.ErrorOutput;
+        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
-            var errors = new List<string>();
-            ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-            ErrorReporter.ErrorOutput("test");
+            ErrorReporter.ReportError("test");
 
             Assert.Single(errors);
             Assert.Equal("test", errors[0]);
         }
-        finally { ErrorReporter.ErrorOutput = prev; }
+        finally { restore(); }
     }
 
     [Fact]

--- a/GodotSharpDI.Runtime.Tests/DeadlockDetectorTests.cs
+++ b/GodotSharpDI.Runtime.Tests/DeadlockDetectorTests.cs
@@ -7,183 +7,154 @@ namespace GodotSharpDI.Runtime.Tests;
 
 public class DeadlockDetectorTests
 {
-    private static (DeadlockDetector detector, List<string> errors, Action restore) CreateDetector()
+    private static (DeadlockDetector detector, List<string> errors, Action<string> errorOutput) CreateDetector()
     {
-        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
-        return (new DeadlockDetector(), errors, restore);
+        var errors = new List<string>();
+        return (new DeadlockDetector(), errors, ErrorReporterHelper.CreateErrorCollector(errors));
     }
 
     [Fact]
     public void ReportError_CapturesOutput()
     {
-        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            ErrorReporter.ReportError("test");
+        var errors = new List<string>();
+        var errorOutput = ErrorReporterHelper.CreateErrorCollector(errors);
 
-            Assert.Single(errors);
-            Assert.Equal("test", errors[0]);
-        }
-        finally { restore(); }
+        ErrorReporter.ReportError("test", errorOutput);
+
+        Assert.Single(errors);
+        Assert.Equal("test", errors[0]);
     }
 
     [Fact]
     public void NoCycle_SingleEdge_NoError()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            // ProviderA provides ServiceA, ProviderB provides ServiceB
-            detector.RegisterServiceProvider("ProviderA", "ServiceA");
-            detector.RegisterServiceProvider("ProviderB", "ServiceB");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            // ProviderA waits for ServiceB (provided by ProviderB)
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB");
+        // ProviderA provides ServiceA, ProviderB provides ServiceB
+        detector.RegisterServiceProvider("ProviderA", "ServiceA");
+        detector.RegisterServiceProvider("ProviderB", "ServiceB");
 
-            Assert.Empty(errors);
-        }
-        finally { restore(); }
+        // ProviderA waits for ServiceB (provided by ProviderB)
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB", errorOutput);
+
+        Assert.Empty(errors);
     }
 
     [Fact]
     public void DirectCycle_Detected()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            // ProviderA provides ServiceA, ProviderB provides ServiceB
-            detector.RegisterServiceProvider("ProviderA", "ServiceA");
-            detector.RegisterServiceProvider("ProviderB", "ServiceB");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            // ProviderA waits for ServiceB - no cycle yet
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB");
-            Assert.Empty(errors);
+        // ProviderA provides ServiceA, ProviderB provides ServiceB
+        detector.RegisterServiceProvider("ProviderA", "ServiceA");
+        detector.RegisterServiceProvider("ProviderB", "ServiceB");
 
-            // ProviderB waits for ServiceA - creates cycle A→B→A
-            detector.TrackAndDetect("GDI_WF:ProviderB:Ctx", "ServiceA");
+        // ProviderA waits for ServiceB - no cycle yet
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB", errorOutput);
+        Assert.Empty(errors);
 
-            Assert.True(errors.Count > 0,
-                "Expected cycle error. ProviderA waits for ServiceB, ProviderB waits for ServiceA.");
-            Assert.Contains("Deadlock", errors[0]);
-        }
-        finally { restore(); }
+        // ProviderB waits for ServiceA - creates cycle A→B→A
+        detector.TrackAndDetect("GDI_WF:ProviderB:Ctx", "ServiceA", errorOutput);
+
+        Assert.True(errors.Count > 0,
+            "Expected cycle error. ProviderA waits for ServiceB, ProviderB waits for ServiceA.");
+        Assert.Contains("Deadlock", errors[0]);
     }
 
     [Fact]
     public void LongerCycle_ABCA_Detected()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            detector.RegisterServiceProvider("ProviderA", "ServiceA");
-            detector.RegisterServiceProvider("ProviderB", "ServiceB");
-            detector.RegisterServiceProvider("ProviderC", "ServiceC");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB");
-            detector.TrackAndDetect("GDI_WF:ProviderB:Ctx", "ServiceC");
-            detector.TrackAndDetect("GDI_WF:ProviderC:Ctx", "ServiceA");
+        detector.RegisterServiceProvider("ProviderA", "ServiceA");
+        detector.RegisterServiceProvider("ProviderB", "ServiceB");
+        detector.RegisterServiceProvider("ProviderC", "ServiceC");
 
-            Assert.Single(errors);
-            Assert.Contains("Deadlock", errors[0]);
-        }
-        finally { restore(); }
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB", errorOutput);
+        detector.TrackAndDetect("GDI_WF:ProviderB:Ctx", "ServiceC", errorOutput);
+        detector.TrackAndDetect("GDI_WF:ProviderC:Ctx", "ServiceA", errorOutput);
+
+        Assert.Single(errors);
+        Assert.Contains("Deadlock", errors[0]);
     }
 
     [Fact]
     public void NoPrefix_Ignored()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            detector.TrackAndDetect("SomeRandomType", "ServiceB");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            Assert.Empty(errors);
-        }
-        finally { restore(); }
+        detector.TrackAndDetect("SomeRandomType", "ServiceB", errorOutput);
+
+        Assert.Empty(errors);
     }
 
     [Fact]
     public void InvalidPrefixFormat_NoColon_Ignored()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            detector.TrackAndDetect("GDI_WF:NoColonHere", "ServiceB");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            Assert.Empty(errors);
-        }
-        finally { restore(); }
+        detector.TrackAndDetect("GDI_WF:NoColonHere", "ServiceB", errorOutput);
+
+        Assert.Empty(errors);
     }
 
     [Fact]
     public void MultipleEdges_NoCycle_NoError()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            detector.RegisterServiceProvider("ProviderA", "ServiceA");
-            detector.RegisterServiceProvider("ProviderB", "ServiceB");
-            detector.RegisterServiceProvider("ProviderC", "ServiceC");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            // ProviderA waits for both ServiceB and ServiceC — no cycle
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB");
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceC");
+        detector.RegisterServiceProvider("ProviderA", "ServiceA");
+        detector.RegisterServiceProvider("ProviderB", "ServiceB");
+        detector.RegisterServiceProvider("ProviderC", "ServiceC");
 
-            Assert.Empty(errors);
-        }
-        finally { restore(); }
+        // ProviderA waits for both ServiceB and ServiceC — no cycle
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB", errorOutput);
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceC", errorOutput);
+
+        Assert.Empty(errors);
     }
 
     [Fact]
     public void SelfReference_Detected()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            // ProviderA provides ServiceA and waits for ServiceA
-            detector.RegisterServiceProvider("ProviderA", "ServiceA");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceA");
+        // ProviderA provides ServiceA and waits for ServiceA
+        detector.RegisterServiceProvider("ProviderA", "ServiceA");
 
-            Assert.Single(errors);
-            Assert.Contains("Deadlock", errors[0]);
-        }
-        finally { restore(); }
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceA", errorOutput);
+
+        Assert.Single(errors);
+        Assert.Contains("Deadlock", errors[0]);
     }
 
     [Fact]
     public void DuplicateEdges_NoExtraError()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            detector.RegisterServiceProvider("ProviderA", "ServiceA");
-            detector.RegisterServiceProvider("ProviderB", "ServiceB");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            // Same edge registered twice
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB");
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB");
-            detector.TrackAndDetect("GDI_WF:ProviderB:Ctx", "ServiceA");
+        detector.RegisterServiceProvider("ProviderA", "ServiceA");
+        detector.RegisterServiceProvider("ProviderB", "ServiceB");
 
-            // Should detect cycle once, not multiple times
-            Assert.Single(errors);
-        }
-        finally { restore(); }
+        // Same edge registered twice
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB", errorOutput);
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "ServiceB", errorOutput);
+        detector.TrackAndDetect("GDI_WF:ProviderB:Ctx", "ServiceA", errorOutput);
+
+        // Should detect cycle once, not multiple times
+        Assert.Single(errors);
     }
 
     [Fact]
     public void UnknownService_NoCycle_NoError()
     {
-        var (detector, errors, restore) = CreateDetector();
-        try
-        {
-            detector.RegisterServiceProvider("ProviderA", "ServiceA");
+        var (detector, errors, errorOutput) = CreateDetector();
 
-            // ProviderA waits for an unknown service (no provider registered)
-            detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "UnknownService");
+        detector.RegisterServiceProvider("ProviderA", "ServiceA");
 
-            Assert.Empty(errors);
-        }
-        finally { restore(); }
+        // ProviderA waits for an unknown service (no provider registered)
+        detector.TrackAndDetect("GDI_WF:ProviderA:Ctx", "UnknownService", errorOutput);
+
+        Assert.Empty(errors);
     }
 }

--- a/GodotSharpDI.Runtime.Tests/Helpers/ErrorReporterHelper.cs
+++ b/GodotSharpDI.Runtime.Tests/Helpers/ErrorReporterHelper.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using GodotSharpDI.Runtime;
+
+namespace GodotSharpDI.Runtime.Tests.Helpers;
+
+public static class ErrorReporterHelper
+{
+    public static (List<string> errors, List<string> warnings, Action restore) Capture()
+    {
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        var prevError = ErrorReporter.ErrorOutput;
+        var prevOutput = ErrorReporter.Output;
+        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
+        ErrorReporter.Output = msg => warnings.Add(msg);
+        return (errors, warnings, () =>
+        {
+            ErrorReporter.ErrorOutput = prevError;
+            ErrorReporter.Output = prevOutput;
+        });
+    }
+
+    public static List<string> CaptureErrors(out Action restore)
+    {
+        var errors = new List<string>();
+        var prev = ErrorReporter.ErrorOutput;
+        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
+        restore = () => ErrorReporter.ErrorOutput = prev;
+        return errors;
+    }
+}

--- a/GodotSharpDI.Runtime.Tests/Helpers/ErrorReporterHelper.cs
+++ b/GodotSharpDI.Runtime.Tests/Helpers/ErrorReporterHelper.cs
@@ -1,32 +1,12 @@
 using System;
 using System.Collections.Generic;
-using GodotSharpDI.Runtime;
 
 namespace GodotSharpDI.Runtime.Tests.Helpers;
 
 public static class ErrorReporterHelper
 {
-    public static (List<string> errors, List<string> warnings, Action restore) Capture()
+    public static Action<string> CreateErrorCollector(List<string> errors)
     {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () =>
-        {
-            ErrorReporter.ErrorOutput = prevError;
-            ErrorReporter.Output = prevOutput;
-        });
-    }
-
-    public static List<string> CaptureErrors(out Action restore)
-    {
-        var errors = new List<string>();
-        var prev = ErrorReporter.ErrorOutput;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        restore = () => ErrorReporter.ErrorOutput = prev;
-        return errors;
+        return msg => errors.Add(msg);
     }
 }

--- a/GodotSharpDI.Runtime.Tests/InjectionExecutorTests.cs
+++ b/GodotSharpDI.Runtime.Tests/InjectionExecutorTests.cs
@@ -1,26 +1,16 @@
 using System;
 using System.Collections.Generic;
+using GodotSharpDI.Runtime.Tests.Helpers;
 using Xunit;
 
 namespace GodotSharpDI.Runtime.Tests;
 
 public class InjectionExecutorTests
 {
-    private static (List<string> errors, List<string> warnings, Action restore) CaptureErrorReporter()
-    {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () => { ErrorReporter.ErrorOutput = prevError; ErrorReporter.Output = prevOutput; });
-    }
-
     [Fact]
     public void Execute_SuccessfulInjection_AssignAndReadyCallbackCalled()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             string? assigned = null;
@@ -50,7 +40,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_NullValue_FailedCallbackCalled()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             string? assigned = null;
@@ -80,7 +70,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_AssignThrows_NotifiesCallbackAsFailureAndReportsError()
     {
-        var (_, warnings, restore) = CaptureErrorReporter();
+        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var resolvedCalled = false;
@@ -103,8 +93,8 @@ public class InjectionExecutorTests
             Assert.False(callbackResults[0]);
             Assert.False(readyCalled);
             Assert.True(resolvedCalled);
-            Assert.NotEmpty(warnings);
-            Assert.Contains("assign broke", warnings[0]);
+            Assert.NotEmpty(errors);
+            Assert.Contains("assign broke", errors[0]);
         }
         finally { restore(); }
     }
@@ -112,7 +102,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_ReadyCallbackThrows_StillNotifiesCallbacksAndReportsError()
     {
-        var (errors, _, restore) = CaptureErrorReporter();
+        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var resolvedCalled = false;
@@ -141,7 +131,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_NullValue_FailedCallbackThrows_StillReportsError()
     {
-        var (_, warnings, restore) = CaptureErrorReporter();
+        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var resolvedCalled = false;
@@ -158,8 +148,8 @@ public class InjectionExecutorTests
                 memberName: "_field");
 
             Assert.True(resolvedCalled);
-            Assert.NotEmpty(warnings);
-            Assert.Contains("fail broke", warnings[0]);
+            Assert.NotEmpty(errors);
+            Assert.Contains("fail broke", errors[0]);
         }
         finally { restore(); }
     }
@@ -167,7 +157,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_CallbackListReceivesTrueOnSuccess()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var results = new List<bool>();
@@ -192,7 +182,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_CallbackListReceivesFalseOnFailure()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var results = new List<bool>();
@@ -217,7 +207,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_CallbackListClearedAfterNotification()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var callbackList = new List<Action<bool>> { _ => { }, _ => { } };
@@ -240,7 +230,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_MultipleCallbacks_AllNotified()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var count = 0;
@@ -269,7 +259,7 @@ public class InjectionExecutorTests
     [Fact]
     public void Execute_OnDependencyResolved_AlwaysCalled()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var callCount = 0;

--- a/GodotSharpDI.Runtime.Tests/InjectionExecutorTests.cs
+++ b/GodotSharpDI.Runtime.Tests/InjectionExecutorTests.cs
@@ -7,287 +7,256 @@ namespace GodotSharpDI.Runtime.Tests;
 
 public class InjectionExecutorTests
 {
+    private static readonly Action<string> NoOp = _ => { };
+
     [Fact]
     public void Execute_SuccessfulInjection_AssignAndReadyCallbackCalled()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            string? assigned = null;
-            var readyCalled = false;
-            var failedCalled = false;
-            var resolvedCalled = false;
-            var callbackList = new List<Action<bool>>();
+        string? assigned = null;
+        var readyCalled = false;
+        var failedCalled = false;
+        var resolvedCalled = false;
+        var callbackList = new List<Action<bool>>();
 
-            InjectionExecutor.Execute(
-                assign: v => assigned = v,
-                value: "hello",
-                readyCallback: v => { readyCalled = true; Assert.Equal("hello", v); },
-                failedCallback: () => failedCalled = true,
-                callbackList: callbackList,
-                onDependencyResolved: () => resolvedCalled = true,
-                typeName: "TestType",
-                memberName: "_field");
+        InjectionExecutor.Execute(
+            assign: v => assigned = v,
+            value: "hello",
+            readyCallback: v => { readyCalled = true; Assert.Equal("hello", v); },
+            failedCallback: () => failedCalled = true,
+            callbackList: callbackList,
+            onDependencyResolved: () => resolvedCalled = true,
+            typeName: "TestType",
+            memberName: "_field",
+            errorOutput: NoOp);
 
-            Assert.Equal("hello", assigned);
-            Assert.True(readyCalled);
-            Assert.False(failedCalled);
-            Assert.True(resolvedCalled);
-        }
-        finally { restore(); }
+        Assert.Equal("hello", assigned);
+        Assert.True(readyCalled);
+        Assert.False(failedCalled);
+        Assert.True(resolvedCalled);
     }
 
     [Fact]
     public void Execute_NullValue_FailedCallbackCalled()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            string? assigned = null;
-            var readyCalled = false;
-            var failedCalled = false;
-            var resolvedCalled = false;
-            var callbackList = new List<Action<bool>>();
+        string? assigned = null;
+        var readyCalled = false;
+        var failedCalled = false;
+        var resolvedCalled = false;
+        var callbackList = new List<Action<bool>>();
 
-            InjectionExecutor.Execute<string>(
-                assign: v => assigned = v,
-                value: null,
-                readyCallback: v => readyCalled = true,
-                failedCallback: () => failedCalled = true,
-                callbackList: callbackList,
-                onDependencyResolved: () => resolvedCalled = true,
-                typeName: "TestType",
-                memberName: "_field");
+        InjectionExecutor.Execute<string>(
+            assign: v => assigned = v,
+            value: null,
+            readyCallback: v => readyCalled = true,
+            failedCallback: () => failedCalled = true,
+            callbackList: callbackList,
+            onDependencyResolved: () => resolvedCalled = true,
+            typeName: "TestType",
+            memberName: "_field",
+            errorOutput: NoOp);
 
-            Assert.Null(assigned);
-            Assert.False(readyCalled);
-            Assert.True(failedCalled);
-            Assert.True(resolvedCalled);
-        }
-        finally { restore(); }
+        Assert.Null(assigned);
+        Assert.False(readyCalled);
+        Assert.True(failedCalled);
+        Assert.True(resolvedCalled);
     }
 
     [Fact]
     public void Execute_AssignThrows_NotifiesCallbackAsFailureAndReportsError()
     {
-        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            var resolvedCalled = false;
-            var readyCalled = false;
-            var callbackResults = new List<bool>();
-            var callbackList = new List<Action<bool>> { ok => callbackResults.Add(ok) };
+        var errors = new List<string>();
+        var errorOutput = ErrorReporterHelper.CreateErrorCollector(errors);
+        var resolvedCalled = false;
+        var readyCalled = false;
+        var callbackResults = new List<bool>();
+        var callbackList = new List<Action<bool>> { ok => callbackResults.Add(ok) };
 
-            InjectionExecutor.Execute<string>(
-                assign: v => throw new InvalidOperationException("assign broke"),
-                value: "val",
-                readyCallback: v => readyCalled = true,
-                failedCallback: null,
-                callbackList: callbackList,
-                onDependencyResolved: () => resolvedCalled = true,
-                typeName: "MyType",
-                memberName: "_field");
+        InjectionExecutor.Execute<string>(
+            assign: v => throw new InvalidOperationException("assign broke"),
+            value: "val",
+            readyCallback: v => readyCalled = true,
+            failedCallback: null,
+            callbackList: callbackList,
+            onDependencyResolved: () => resolvedCalled = true,
+            typeName: "MyType",
+            memberName: "_field",
+            errorOutput: errorOutput);
 
-            // Assign failed → callback notified with false, readyCallback not called
-            Assert.Single(callbackResults);
-            Assert.False(callbackResults[0]);
-            Assert.False(readyCalled);
-            Assert.True(resolvedCalled);
-            Assert.NotEmpty(errors);
-            Assert.Contains("assign broke", errors[0]);
-        }
-        finally { restore(); }
+        // Assign failed → callback notified with false, readyCallback not called
+        Assert.Single(callbackResults);
+        Assert.False(callbackResults[0]);
+        Assert.False(readyCalled);
+        Assert.True(resolvedCalled);
+        Assert.NotEmpty(errors);
+        Assert.Contains("assign broke", errors[0]);
     }
 
     [Fact]
     public void Execute_ReadyCallbackThrows_StillNotifiesCallbacksAndReportsError()
     {
-        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            var resolvedCalled = false;
-            var callbackResults = new List<bool>();
-            var callbackList = new List<Action<bool>> { ok => callbackResults.Add(ok) };
+        var errors = new List<string>();
+        var errorOutput = ErrorReporterHelper.CreateErrorCollector(errors);
+        var resolvedCalled = false;
+        var callbackResults = new List<bool>();
+        var callbackList = new List<Action<bool>> { ok => callbackResults.Add(ok) };
 
-            InjectionExecutor.Execute<string>(
-                assign: v => { },
-                value: "val",
-                readyCallback: v => throw new InvalidOperationException("ready broke"),
-                failedCallback: null,
-                callbackList: callbackList,
-                onDependencyResolved: () => resolvedCalled = true,
-                typeName: "MyType",
-                memberName: "_field");
+        InjectionExecutor.Execute<string>(
+            assign: v => { },
+            value: "val",
+            readyCallback: v => throw new InvalidOperationException("ready broke"),
+            failedCallback: null,
+            callbackList: callbackList,
+            onDependencyResolved: () => resolvedCalled = true,
+            typeName: "MyType",
+            memberName: "_field",
+            errorOutput: errorOutput);
 
-            Assert.Single(callbackResults);
-            Assert.True(callbackResults[0]);
-            Assert.True(resolvedCalled);
-            Assert.NotEmpty(errors);
-            Assert.Contains("ready broke", errors[0]);
-        }
-        finally { restore(); }
+        Assert.Single(callbackResults);
+        Assert.True(callbackResults[0]);
+        Assert.True(resolvedCalled);
+        Assert.NotEmpty(errors);
+        Assert.Contains("ready broke", errors[0]);
     }
 
     [Fact]
     public void Execute_NullValue_FailedCallbackThrows_StillReportsError()
     {
-        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            var resolvedCalled = false;
-            var callbackList = new List<Action<bool>>();
+        var errors = new List<string>();
+        var errorOutput = ErrorReporterHelper.CreateErrorCollector(errors);
+        var resolvedCalled = false;
+        var callbackList = new List<Action<bool>>();
 
-            InjectionExecutor.Execute<string>(
-                assign: v => { },
-                value: null,
-                readyCallback: null,
-                failedCallback: () => throw new InvalidOperationException("fail broke"),
-                callbackList: callbackList,
-                onDependencyResolved: () => resolvedCalled = true,
-                typeName: "MyType",
-                memberName: "_field");
+        InjectionExecutor.Execute<string>(
+            assign: v => { },
+            value: null,
+            readyCallback: null,
+            failedCallback: () => throw new InvalidOperationException("fail broke"),
+            callbackList: callbackList,
+            onDependencyResolved: () => resolvedCalled = true,
+            typeName: "MyType",
+            memberName: "_field",
+            errorOutput: errorOutput);
 
-            Assert.True(resolvedCalled);
-            Assert.NotEmpty(errors);
-            Assert.Contains("fail broke", errors[0]);
-        }
-        finally { restore(); }
+        Assert.True(resolvedCalled);
+        Assert.NotEmpty(errors);
+        Assert.Contains("fail broke", errors[0]);
     }
 
     [Fact]
     public void Execute_CallbackListReceivesTrueOnSuccess()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            var results = new List<bool>();
-            var callbackList = new List<Action<bool>> { ok => results.Add(ok) };
+        var results = new List<bool>();
+        var callbackList = new List<Action<bool>> { ok => results.Add(ok) };
 
-            InjectionExecutor.Execute<string>(
-                assign: v => { },
-                value: "ok",
-                readyCallback: null,
-                failedCallback: null,
-                callbackList: callbackList,
-                onDependencyResolved: () => { },
-                typeName: "T",
-                memberName: "_f");
+        InjectionExecutor.Execute<string>(
+            assign: v => { },
+            value: "ok",
+            readyCallback: null,
+            failedCallback: null,
+            callbackList: callbackList,
+            onDependencyResolved: () => { },
+            typeName: "T",
+            memberName: "_f",
+            errorOutput: NoOp);
 
-            Assert.Single(results);
-            Assert.True(results[0]);
-        }
-        finally { restore(); }
+        Assert.Single(results);
+        Assert.True(results[0]);
     }
 
     [Fact]
     public void Execute_CallbackListReceivesFalseOnFailure()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            var results = new List<bool>();
-            var callbackList = new List<Action<bool>> { ok => results.Add(ok) };
+        var results = new List<bool>();
+        var callbackList = new List<Action<bool>> { ok => results.Add(ok) };
 
-            InjectionExecutor.Execute<string>(
-                assign: v => { },
-                value: null,
-                readyCallback: null,
-                failedCallback: null,
-                callbackList: callbackList,
-                onDependencyResolved: () => { },
-                typeName: "T",
-                memberName: "_f");
+        InjectionExecutor.Execute<string>(
+            assign: v => { },
+            value: null,
+            readyCallback: null,
+            failedCallback: null,
+            callbackList: callbackList,
+            onDependencyResolved: () => { },
+            typeName: "T",
+            memberName: "_f",
+            errorOutput: NoOp);
 
-            Assert.Single(results);
-            Assert.False(results[0]);
-        }
-        finally { restore(); }
+        Assert.Single(results);
+        Assert.False(results[0]);
     }
 
     [Fact]
     public void Execute_CallbackListClearedAfterNotification()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            var callbackList = new List<Action<bool>> { _ => { }, _ => { } };
+        var callbackList = new List<Action<bool>> { _ => { }, _ => { } };
 
-            InjectionExecutor.Execute<string>(
-                assign: v => { },
-                value: "ok",
-                readyCallback: null,
-                failedCallback: null,
-                callbackList: callbackList,
-                onDependencyResolved: () => { },
-                typeName: "T",
-                memberName: "_f");
+        InjectionExecutor.Execute<string>(
+            assign: v => { },
+            value: "ok",
+            readyCallback: null,
+            failedCallback: null,
+            callbackList: callbackList,
+            onDependencyResolved: () => { },
+            typeName: "T",
+            memberName: "_f",
+            errorOutput: NoOp);
 
-            Assert.Empty(callbackList);
-        }
-        finally { restore(); }
+        Assert.Empty(callbackList);
     }
 
     [Fact]
     public void Execute_MultipleCallbacks_AllNotified()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
+        var count = 0;
+        var callbackList = new List<Action<bool>>
         {
-            var count = 0;
-            var callbackList = new List<Action<bool>>
-            {
-                _ => count++,
-                _ => count++,
-                _ => count++,
-            };
+            _ => count++,
+            _ => count++,
+            _ => count++,
+        };
 
-            InjectionExecutor.Execute<string>(
-                assign: v => { },
-                value: "ok",
-                readyCallback: null,
-                failedCallback: null,
-                callbackList: callbackList,
-                onDependencyResolved: () => { },
-                typeName: "T",
-                memberName: "_f");
+        InjectionExecutor.Execute<string>(
+            assign: v => { },
+            value: "ok",
+            readyCallback: null,
+            failedCallback: null,
+            callbackList: callbackList,
+            onDependencyResolved: () => { },
+            typeName: "T",
+            memberName: "_f",
+            errorOutput: NoOp);
 
-            Assert.Equal(3, count);
-        }
-        finally { restore(); }
+        Assert.Equal(3, count);
     }
 
     [Fact]
     public void Execute_OnDependencyResolved_AlwaysCalled()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            var callCount = 0;
+        var callCount = 0;
 
-            // Success case
-            InjectionExecutor.Execute<string>(
-                assign: v => { },
-                value: "ok",
-                readyCallback: null,
-                failedCallback: null,
-                callbackList: new List<Action<bool>>(),
-                onDependencyResolved: () => callCount++,
-                typeName: "T",
-                memberName: "_f");
+        // Success case
+        InjectionExecutor.Execute<string>(
+            assign: v => { },
+            value: "ok",
+            readyCallback: null,
+            failedCallback: null,
+            callbackList: new List<Action<bool>>(),
+            onDependencyResolved: () => callCount++,
+            typeName: "T",
+            memberName: "_f",
+            errorOutput: NoOp);
 
-            // Failure case
-            InjectionExecutor.Execute<string>(
-                assign: v => { },
-                value: null,
-                readyCallback: null,
-                failedCallback: null,
-                callbackList: new List<Action<bool>>(),
-                onDependencyResolved: () => callCount++,
-                typeName: "T",
-                memberName: "_f");
+        // Failure case
+        InjectionExecutor.Execute<string>(
+            assign: v => { },
+            value: null,
+            readyCallback: null,
+            failedCallback: null,
+            callbackList: new List<Action<bool>>(),
+            onDependencyResolved: () => callCount++,
+            typeName: "T",
+            memberName: "_f",
+            errorOutput: NoOp);
 
-            Assert.Equal(2, callCount);
-        }
-        finally { restore(); }
+        Assert.Equal(2, callCount);
     }
 }

--- a/GodotSharpDI.Runtime.Tests/SyncProviderRunnerTests.cs
+++ b/GodotSharpDI.Runtime.Tests/SyncProviderRunnerTests.cs
@@ -7,64 +7,56 @@ namespace GodotSharpDI.Runtime.Tests;
 
 public class SyncProviderRunnerTests
 {
+    private static readonly Action<string> NoOp = _ => { };
+
     [Fact]
     public void Run_Success_InstanceProvided()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            var instance = new object();
-            object? provided = null;
-            string? providerType = null;
+        var instance = new object();
+        object? provided = null;
+        string? providerType = null;
 
-            SyncProviderRunner.Run(
-                () => instance,
-                (inst, pt) => { provided = inst; providerType = pt; },
-                "TestProvider");
+        SyncProviderRunner.Run(
+            () => instance,
+            (inst, pt) => { provided = inst; providerType = pt; },
+            "TestProvider",
+            NoOp);
 
-            Assert.Same(instance, provided);
-            Assert.Equal("TestProvider", providerType);
-        }
-        finally { restore(); }
+        Assert.Same(instance, provided);
+        Assert.Equal("TestProvider", providerType);
     }
 
     [Fact]
     public void Run_FactoryThrows_NullProvidedAndErrorReported()
     {
-        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            object? provided = null;
-            string? providerType = null;
+        var errors = new List<string>();
+        var errorOutput = ErrorReporterHelper.CreateErrorCollector(errors);
+        object? provided = null;
+        string? providerType = null;
 
-            SyncProviderRunner.Run<object>(
-                () => throw new InvalidOperationException("factory broke"),
-                (inst, pt) => { provided = inst; providerType = pt; },
-                "TestProvider");
+        SyncProviderRunner.Run<object>(
+            () => throw new InvalidOperationException("factory broke"),
+            (inst, pt) => { provided = inst; providerType = pt; },
+            "TestProvider",
+            errorOutput);
 
-            Assert.Null(provided);
-            Assert.Equal("TestProvider", providerType);
-            Assert.NotEmpty(errors);
-            Assert.Contains("factory broke", errors[0]);
-        }
-        finally { restore(); }
+        Assert.Null(provided);
+        Assert.Equal("TestProvider", providerType);
+        Assert.NotEmpty(errors);
+        Assert.Contains("factory broke", errors[0]);
     }
 
     [Fact]
     public void Run_ProviderTypePassedToProvide()
     {
-        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
-        try
-        {
-            string? capturedType = null;
+        string? capturedType = null;
 
-            SyncProviderRunner.Run(
-                () => new object(),
-                (_, pt) => capturedType = pt,
-                "MyHost");
+        SyncProviderRunner.Run(
+            () => new object(),
+            (_, pt) => capturedType = pt,
+            "MyHost",
+            NoOp);
 
-            Assert.Equal("MyHost", capturedType);
-        }
-        finally { restore(); }
+        Assert.Equal("MyHost", capturedType);
     }
 }

--- a/GodotSharpDI.Runtime.Tests/SyncProviderRunnerTests.cs
+++ b/GodotSharpDI.Runtime.Tests/SyncProviderRunnerTests.cs
@@ -1,26 +1,16 @@
 using System;
 using System.Collections.Generic;
+using GodotSharpDI.Runtime.Tests.Helpers;
 using Xunit;
 
 namespace GodotSharpDI.Runtime.Tests;
 
 public class SyncProviderRunnerTests
 {
-    private static (List<string> errors, List<string> warnings, Action restore) CaptureErrorReporter()
-    {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () => { ErrorReporter.ErrorOutput = prevError; ErrorReporter.Output = prevOutput; });
-    }
-
     [Fact]
     public void Run_Success_InstanceProvided()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             var instance = new object();
@@ -41,7 +31,7 @@ public class SyncProviderRunnerTests
     [Fact]
     public void Run_FactoryThrows_NullProvidedAndErrorReported()
     {
-        var (_, warnings, restore) = CaptureErrorReporter();
+        var errors = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             object? provided = null;
@@ -54,8 +44,8 @@ public class SyncProviderRunnerTests
 
             Assert.Null(provided);
             Assert.Equal("TestProvider", providerType);
-            Assert.NotEmpty(warnings);
-            Assert.Contains("factory broke", warnings[0]);
+            Assert.NotEmpty(errors);
+            Assert.Contains("factory broke", errors[0]);
         }
         finally { restore(); }
     }
@@ -63,7 +53,7 @@ public class SyncProviderRunnerTests
     [Fact]
     public void Run_ProviderTypePassedToProvide()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var _ = ErrorReporterHelper.CaptureErrors(out var restore);
         try
         {
             string? capturedType = null;

--- a/GodotSharpDI.Runtime.Tests/WaitForCoordinatorTests.cs
+++ b/GodotSharpDI.Runtime.Tests/WaitForCoordinatorTests.cs
@@ -9,169 +9,145 @@ namespace GodotSharpDI.Runtime.Tests;
 
 public class WaitForCoordinatorTests
 {
+    private static readonly Action<string> NoOp = _ => { };
+
     [Fact]
     public void SingleDependency_Triggered_OnAllResolvedCalled()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
+        var resolved = false;
+        var list = new List<Action<bool>>();
+
+        var coordinator = new WaitForCoordinator(1, () =>
         {
-            var resolved = false;
-            var list = new List<Action<bool>>();
+            resolved = true;
+            return Task.CompletedTask;
+        });
 
-            var coordinator = new WaitForCoordinator(1, () =>
-            {
-                resolved = true;
-                return Task.CompletedTask;
-            });
+        coordinator.Register(list, "dep", "member", NoOp, a => a());
 
-            coordinator.Register(list, "dep", "member", a => a());
+        Assert.Single(list);
+        Assert.False(resolved);
 
-            Assert.Single(list);
-            Assert.False(resolved);
+        // Trigger the callback
+        list[0].Invoke(true);
 
-            // Trigger the callback
-            list[0].Invoke(true);
-
-            // OnAllResolved is called synchronously via ContinueWith, need brief wait
-            Thread.Sleep(50);
-            Assert.True(resolved);
-        }
-        finally { restore(); }
+        // OnAllResolved is called synchronously via ContinueWith, need brief wait
+        Thread.Sleep(50);
+        Assert.True(resolved);
     }
 
     [Fact]
     public void MultipleDependencies_AllTriggered_OnAllResolvedCalled()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
+        var resolved = false;
+        var list1 = new List<Action<bool>>();
+        var list2 = new List<Action<bool>>();
+        var list3 = new List<Action<bool>>();
+
+        var coordinator = new WaitForCoordinator(3, () =>
         {
-            var resolved = false;
-            var list1 = new List<Action<bool>>();
-            var list2 = new List<Action<bool>>();
-            var list3 = new List<Action<bool>>();
+            resolved = true;
+            return Task.CompletedTask;
+        });
 
-            var coordinator = new WaitForCoordinator(3, () =>
-            {
-                resolved = true;
-                return Task.CompletedTask;
-            });
+        coordinator.Register(list1, "dep1", "member", NoOp, a => a());
+        coordinator.Register(list2, "dep2", "member", NoOp, a => a());
+        coordinator.Register(list3, "dep3", "member", NoOp, a => a());
 
-            coordinator.Register(list1, "dep1", "member", a => a());
-            coordinator.Register(list2, "dep2", "member", a => a());
-            coordinator.Register(list3, "dep3", "member", a => a());
+        list1[0].Invoke(true);
+        Thread.Sleep(20);
+        Assert.False(resolved);
 
-            list1[0].Invoke(true);
-            Thread.Sleep(20);
-            Assert.False(resolved);
+        list2[0].Invoke(true);
+        Thread.Sleep(20);
+        Assert.False(resolved);
 
-            list2[0].Invoke(true);
-            Thread.Sleep(20);
-            Assert.False(resolved);
-
-            list3[0].Invoke(true);
-            Thread.Sleep(50);
-            Assert.True(resolved);
-        }
-        finally { restore(); }
+        list3[0].Invoke(true);
+        Thread.Sleep(50);
+        Assert.True(resolved);
     }
 
     [Fact]
     public void DependencyFails_StillDecrementsCount()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
+        var resolved = false;
+        var list1 = new List<Action<bool>>();
+        var list2 = new List<Action<bool>>();
+
+        var coordinator = new WaitForCoordinator(2, () =>
         {
-            var resolved = false;
-            var list1 = new List<Action<bool>>();
-            var list2 = new List<Action<bool>>();
+            resolved = true;
+            return Task.CompletedTask;
+        });
 
-            var coordinator = new WaitForCoordinator(2, () =>
-            {
-                resolved = true;
-                return Task.CompletedTask;
-            });
+        coordinator.Register(list1, "dep1", "member", NoOp, a => a());
+        coordinator.Register(list2, "dep2", "member", NoOp, a => a());
 
-            coordinator.Register(list1, "dep1", "member", a => a());
-            coordinator.Register(list2, "dep2", "member", a => a());
+        // First dependency fails
+        list1[0].Invoke(false);
+        Thread.Sleep(20);
+        Assert.False(resolved);
 
-            // First dependency fails
-            list1[0].Invoke(false);
-            Thread.Sleep(20);
-            Assert.False(resolved);
-
-            // Second dependency succeeds
-            list2[0].Invoke(true);
-            Thread.Sleep(50);
-            Assert.True(resolved);
-        }
-        finally { restore(); }
+        // Second dependency succeeds
+        list2[0].Invoke(true);
+        Thread.Sleep(50);
+        Assert.True(resolved);
     }
 
     [Fact]
     public void DependencyFails_ReportsError()
     {
-        var (errors, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var list = new List<Action<bool>>();
+        var errors = new List<string>();
+        var errorOutput = ErrorReporterHelper.CreateErrorCollector(errors);
+        var list = new List<Action<bool>>();
 
-            var coordinator = new WaitForCoordinator(1, () => Task.CompletedTask);
-            coordinator.Register(list, "myDep", "myMember", a => a());
+        var coordinator = new WaitForCoordinator(1, () => Task.CompletedTask);
+        coordinator.Register(list, "myDep", "myMember", errorOutput, a => a());
 
-            list[0].Invoke(false);
+        list[0].Invoke(false);
 
-            Thread.Sleep(50);
-            Assert.NotEmpty(errors);
-            Assert.Contains("myDep", errors[0]);
-            Assert.Contains("myMember", errors[0]);
-        }
-        finally { restore(); }
+        Thread.Sleep(50);
+        Assert.NotEmpty(errors);
+        Assert.Contains("myDep", errors[0]);
+        Assert.Contains("myMember", errors[0]);
     }
 
     [Fact]
     public void OnAllResolvedThrows_ErrorReportedViaDispatch()
     {
-        var (errors, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var list = new List<Action<bool>>();
+        var errors = new List<string>();
+        var errorOutput = ErrorReporterHelper.CreateErrorCollector(errors);
+        var list = new List<Action<bool>>();
 
-            // Use Task.FromException so the exception is captured by ContinueWith
-            // (synchronous throw would propagate before ContinueWith is set up)
-            var coordinator = new WaitForCoordinator(1, () =>
-                Task.FromException(new InvalidOperationException("callback broke")));
+        // Use Task.FromException so the exception is captured by ContinueWith
+        // (synchronous throw would propagate before ContinueWith is set up)
+        var coordinator = new WaitForCoordinator(1, () =>
+            Task.FromException(new InvalidOperationException("callback broke")));
 
-            coordinator.Register(list, "dep", "member", a => a());
+        coordinator.Register(list, "dep", "member", errorOutput, a => a());
 
-            list[0].Invoke(true);
+        list[0].Invoke(true);
 
-            // ContinueWith error is dispatched back to main thread
-            Thread.Sleep(100);
-            Assert.NotEmpty(errors);
-            Assert.Contains("callback broke", errors[0]);
-        }
-        finally { restore(); }
+        // ContinueWith error is dispatched back to main thread
+        Thread.Sleep(100);
+        Assert.NotEmpty(errors);
+        Assert.Contains("callback broke", errors[0]);
     }
 
     [Fact]
     public void EmptyDependencyCount_OnAllResolvedCalledImmediately()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
+        // Edge case: 0 dependencies — onAllResolved should never be called
+        // (caller should handle this, but verify no crash)
+        var resolved = false;
+        var coordinator = new WaitForCoordinator(0, () =>
         {
-            // Edge case: 0 dependencies — onAllResolved should never be called
-            // (caller should handle this, but verify no crash)
-            var resolved = false;
-            var coordinator = new WaitForCoordinator(0, () =>
-            {
-                resolved = true;
-                return Task.CompletedTask;
-            });
+            resolved = true;
+            return Task.CompletedTask;
+        });
 
-            // No register calls — nothing to trigger
-            Thread.Sleep(50);
-            Assert.False(resolved);
-        }
-        finally { restore(); }
+        // No register calls — nothing to trigger
+        Thread.Sleep(50);
+        Assert.False(resolved);
     }
 }

--- a/GodotSharpDI.Runtime.Tests/WaitForCoordinatorTests.cs
+++ b/GodotSharpDI.Runtime.Tests/WaitForCoordinatorTests.cs
@@ -2,27 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using GodotSharpDI.Runtime.Tests.Helpers;
 using Xunit;
 
 namespace GodotSharpDI.Runtime.Tests;
 
 public class WaitForCoordinatorTests
 {
-    private static (List<string> errors, List<string> warnings, Action restore) CaptureErrorReporter()
-    {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () => { ErrorReporter.ErrorOutput = prevError; ErrorReporter.Output = prevOutput; });
-    }
-
     [Fact]
     public void SingleDependency_Triggered_OnAllResolvedCalled()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var resolved = false;
@@ -34,7 +24,7 @@ public class WaitForCoordinatorTests
                 return Task.CompletedTask;
             });
 
-            coordinator.Register(list, "dep", "member", ErrorReporter.ErrorOutput, a => a());
+            coordinator.Register(list, "dep", "member", a => a());
 
             Assert.Single(list);
             Assert.False(resolved);
@@ -52,7 +42,7 @@ public class WaitForCoordinatorTests
     [Fact]
     public void MultipleDependencies_AllTriggered_OnAllResolvedCalled()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var resolved = false;
@@ -66,9 +56,9 @@ public class WaitForCoordinatorTests
                 return Task.CompletedTask;
             });
 
-            coordinator.Register(list1, "dep1", "member", ErrorReporter.ErrorOutput, a => a());
-            coordinator.Register(list2, "dep2", "member", ErrorReporter.ErrorOutput, a => a());
-            coordinator.Register(list3, "dep3", "member", ErrorReporter.ErrorOutput, a => a());
+            coordinator.Register(list1, "dep1", "member", a => a());
+            coordinator.Register(list2, "dep2", "member", a => a());
+            coordinator.Register(list3, "dep3", "member", a => a());
 
             list1[0].Invoke(true);
             Thread.Sleep(20);
@@ -88,7 +78,7 @@ public class WaitForCoordinatorTests
     [Fact]
     public void DependencyFails_StillDecrementsCount()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var resolved = false;
@@ -101,8 +91,8 @@ public class WaitForCoordinatorTests
                 return Task.CompletedTask;
             });
 
-            coordinator.Register(list1, "dep1", "member", ErrorReporter.ErrorOutput, a => a());
-            coordinator.Register(list2, "dep2", "member", ErrorReporter.ErrorOutput, a => a());
+            coordinator.Register(list1, "dep1", "member", a => a());
+            coordinator.Register(list2, "dep2", "member", a => a());
 
             // First dependency fails
             list1[0].Invoke(false);
@@ -120,13 +110,13 @@ public class WaitForCoordinatorTests
     [Fact]
     public void DependencyFails_ReportsError()
     {
-        var (errors, _, restore) = CaptureErrorReporter();
+        var (errors, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var list = new List<Action<bool>>();
 
             var coordinator = new WaitForCoordinator(1, () => Task.CompletedTask);
-            coordinator.Register(list, "myDep", "myMember", ErrorReporter.ErrorOutput, a => a());
+            coordinator.Register(list, "myDep", "myMember", a => a());
 
             list[0].Invoke(false);
 
@@ -141,7 +131,7 @@ public class WaitForCoordinatorTests
     [Fact]
     public void OnAllResolvedThrows_ErrorReportedViaDispatch()
     {
-        var (errors, _, restore) = CaptureErrorReporter();
+        var (errors, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var list = new List<Action<bool>>();
@@ -151,7 +141,7 @@ public class WaitForCoordinatorTests
             var coordinator = new WaitForCoordinator(1, () =>
                 Task.FromException(new InvalidOperationException("callback broke")));
 
-            coordinator.Register(list, "dep", "member", ErrorReporter.ErrorOutput, a => a());
+            coordinator.Register(list, "dep", "member", a => a());
 
             list[0].Invoke(true);
 
@@ -166,7 +156,7 @@ public class WaitForCoordinatorTests
     [Fact]
     public void EmptyDependencyCount_OnAllResolvedCalledImmediately()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             // Edge case: 0 dependencies — onAllResolved should never be called

--- a/GodotSharpDI.Runtime/AsyncProviderRunner.cs
+++ b/GodotSharpDI.Runtime/AsyncProviderRunner.cs
@@ -7,9 +7,6 @@ namespace GodotSharpDI.Runtime;
 /// <summary>
 /// Runs an asynchronous service provider with cancellation and error handling.
 /// Replaces the ~35-line ProvideAsync_xxx method generated per async member.
-///
-/// Godot-specific operations (Callable.From, GD.PrintErr) are injected as delegates
-/// to keep this class compatible with netstandard2.0.
 /// </summary>
 public static class AsyncProviderRunner
 {
@@ -28,9 +25,6 @@ public static class AsyncProviderRunner
     /// Cancellation token (typically __lifetime_cancellation_tokens.Token).
     /// Cancelled when the node exits the scene tree.
     /// </param>
-    /// <param name="reportError">
-    /// Error reporting callback. Typically <c>msg => GD.PrintErr(msg)</c>.
-    /// </param>
     /// <param name="dispatchToMainThread">
     /// Main-thread dispatcher. Typically <c>action => Callable.From(action).CallDeferred()</c>.
     /// </param>
@@ -39,7 +33,6 @@ public static class AsyncProviderRunner
         Action<T?, string> provide,
         string providerType,
         CancellationToken ct,
-        Action<string> reportError,
         Action<Action> dispatchToMainThread) where T : class
     {
         try
@@ -61,7 +54,7 @@ public static class AsyncProviderRunner
         {
             if (ct.IsCancellationRequested) return;
 
-            reportError($"[GodotSharpDI] Async provider for {typeof(T).Name} threw: {ex.Message}");
+            ErrorReporter.ReportAsyncProviderThrew(typeof(T).Name, ex);
 
             dispatchToMainThread(() =>
             {

--- a/GodotSharpDI.Runtime/AsyncProviderRunner.cs
+++ b/GodotSharpDI.Runtime/AsyncProviderRunner.cs
@@ -7,6 +7,9 @@ namespace GodotSharpDI.Runtime;
 /// <summary>
 /// Runs an asynchronous service provider with cancellation and error handling.
 /// Replaces the ~35-line ProvideAsync_xxx method generated per async member.
+///
+/// Godot-specific operations (Callable.From, GD.PrintErr) are injected as delegates
+/// to keep this class compatible with netstandard2.0.
 /// </summary>
 public static class AsyncProviderRunner
 {
@@ -25,6 +28,9 @@ public static class AsyncProviderRunner
     /// Cancellation token (typically __lifetime_cancellation_tokens.Token).
     /// Cancelled when the node exits the scene tree.
     /// </param>
+    /// <param name="errorOutput">
+    /// Error reporting callback. Typically <c>msg => GD.PrintErr(msg)</c>.
+    /// </param>
     /// <param name="dispatchToMainThread">
     /// Main-thread dispatcher. Typically <c>action => Callable.From(action).CallDeferred()</c>.
     /// </param>
@@ -33,6 +39,7 @@ public static class AsyncProviderRunner
         Action<T?, string> provide,
         string providerType,
         CancellationToken ct,
+        Action<string> errorOutput,
         Action<Action> dispatchToMainThread) where T : class
     {
         try
@@ -54,7 +61,7 @@ public static class AsyncProviderRunner
         {
             if (ct.IsCancellationRequested) return;
 
-            ErrorReporter.ReportAsyncProviderThrew(typeof(T).Name, ex);
+            ErrorReporter.ReportAsyncProviderThrew(typeof(T).Name, ex, errorOutput);
 
             dispatchToMainThread(() =>
             {

--- a/GodotSharpDI.Runtime/DeadlockDetector.cs
+++ b/GodotSharpDI.Runtime/DeadlockDetector.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace GodotSharpDI.Runtime;
@@ -37,9 +38,9 @@ public sealed class DeadlockDetector
     /// <summary>
     /// Parse the <c>GDI_WF:</c> prefix from <paramref name="requestorType"/>,
     /// record the edge, and run DFS to detect a cycle.
-    /// If a cycle is found, an error is reported via <see cref="ErrorReporter.ErrorOutput"/>.
+    /// If a cycle is found, an error is reported via <paramref name="errorOutput"/>.
     /// </summary>
-    public void TrackAndDetect(string requestorType, string waitingForTypeName)
+    public void TrackAndDetect(string requestorType, string waitingForTypeName, Action<string> errorOutput)
     {
         const string prefix = "GDI_WF:";
         if (!requestorType.StartsWith(prefix))
@@ -77,7 +78,8 @@ public sealed class DeadlockDetector
             {
                 // Self-dependency
                 ErrorReporter.ReportError(
-                    "[GodotSharpDI] Runtime WaitFor Deadlock: " + providerName + " -> " + waitingForTypeName);
+                    "[GodotSharpDI] Runtime WaitFor Deadlock: " + providerName + " -> " + waitingForTypeName,
+                    errorOutput);
                 continue;
             }
 
@@ -90,7 +92,7 @@ public sealed class DeadlockDetector
             if (cycle != null)
             {
                 var path = providerName + " -> " + string.Join(" -> ", cycle);
-                ErrorReporter.ReportError("[GodotSharpDI] Runtime WaitFor Deadlock: " + path);
+                ErrorReporter.ReportError("[GodotSharpDI] Runtime WaitFor Deadlock: " + path, errorOutput);
             }
         }
     }

--- a/GodotSharpDI.Runtime/DeadlockDetector.cs
+++ b/GodotSharpDI.Runtime/DeadlockDetector.cs
@@ -76,7 +76,7 @@ public sealed class DeadlockDetector
             if (targetProvider == providerName)
             {
                 // Self-dependency
-                ErrorReporter.ErrorOutput(
+                ErrorReporter.ReportError(
                     "[GodotSharpDI] Runtime WaitFor Deadlock: " + providerName + " -> " + waitingForTypeName);
                 continue;
             }
@@ -90,7 +90,7 @@ public sealed class DeadlockDetector
             if (cycle != null)
             {
                 var path = providerName + " -> " + string.Join(" -> ", cycle);
-                ErrorReporter.ErrorOutput("[GodotSharpDI] Runtime WaitFor Deadlock: " + path);
+                ErrorReporter.ReportError("[GodotSharpDI] Runtime WaitFor Deadlock: " + path);
             }
         }
     }

--- a/GodotSharpDI.Runtime/ErrorReporter.cs
+++ b/GodotSharpDI.Runtime/ErrorReporter.cs
@@ -1,35 +1,23 @@
 using System;
 using System.Text;
-using Godot;
 
 namespace GodotSharpDI.Runtime;
 
 /// <summary>
 /// Centralized error message formatting for GodotSharpDI runtime.
 /// All error messages follow a consistent structured format.
-/// The actual output is delegated to a configurable callback (defaults to System.Diagnostics.Debug.WriteLine).
+/// The actual output is delegated to a configurable callback passed by the caller.
 /// </summary>
 public static class ErrorReporter
 {
-    /// <summary>
-    /// Warning-level output callback. Defaults to <see cref="Godot.GD.PushWarning(object?[])"/>.
-    /// Users can override this to redirect warnings.
-    /// </summary>
-    internal static Action<string> Output { get; set; } = GD.PushWarning;
-
-    /// <summary>
-    /// Error-level output callback. Defaults to <see cref="Godot.GD.PrintErr(object?[])"/>.
-    /// Users can override this to redirect errors.
-    /// </summary>
-    internal static Action<string> ErrorOutput { get; set; } = GD.PrintErr;
-
     // ─── Injection errors ────────────────────────────────────────────
 
     public static void ReportInjectionAssignFailed(
         string typeName,
         string memberName,
         string memberType,
-        Exception ex
+        Exception ex,
+        Action<string> errorOutput
     )
     {
         var sb = new StringBuilder()
@@ -38,14 +26,15 @@ public static class ErrorReporter
             .AppendLine($"  Member: {memberName}")
             .AppendLine($"  Member Type: {memberType}")
             .AppendLine($"  Exception: {ex}");
-        ErrorOutput(sb.ToString());
+        errorOutput(sb.ToString());
     }
 
     public static void ReportInjectionReadyCallbackFailed(
         string typeName,
         string memberName,
         string memberType,
-        Exception ex
+        Exception ex,
+        Action<string> errorOutput
     )
     {
         var sb = new StringBuilder()
@@ -54,14 +43,15 @@ public static class ErrorReporter
             .AppendLine($"  Member: {memberName}")
             .AppendLine($"  Member Type: {memberType}")
             .AppendLine($"  Exception: {ex}");
-        ErrorOutput(sb.ToString());
+        errorOutput(sb.ToString());
     }
 
     public static void ReportInjectionFailedCallbackFailed(
         string typeName,
         string memberName,
         string memberType,
-        Exception ex
+        Exception ex,
+        Action<string> errorOutput
     )
     {
         var sb = new StringBuilder()
@@ -70,37 +60,29 @@ public static class ErrorReporter
             .AppendLine($"  Member: {memberName}")
             .AppendLine($"  Member Type: {memberType}")
             .AppendLine($"  Exception: {ex}");
-        ErrorOutput(sb.ToString());
+        errorOutput(sb.ToString());
     }
 
     // ─── Provider errors ─────────────────────────────────────────────
 
-    public static void ReportProviderThrew(string implType, Exception ex)
+    public static void ReportProviderThrew(string implType, Exception ex, Action<string> errorOutput)
     {
-        ErrorOutput($"[GodotSharpDI] Provider for {implType} threw: {ex}");
+        errorOutput($"[GodotSharpDI] Provider for {implType} threw: {ex}");
     }
 
-    public static void ReportAsyncProviderThrew(string implType, Exception ex)
+    public static void ReportAsyncProviderThrew(string implType, Exception ex, Action<string> errorOutput)
     {
-        ErrorOutput($"[GodotSharpDI] Async provider for {implType} threw: {ex}");
+        errorOutput($"[GodotSharpDI] Async provider for {implType} threw: {ex}");
     }
 
     // ─── Convenience methods ──────────────────────────────────────────
 
     /// <summary>
-    /// Report an error-level message via <see cref="ErrorOutput"/>.
+    /// Report an error-level message via the provided callback.
     /// </summary>
-    public static void ReportError(string message)
+    public static void ReportError(string message, Action<string> errorOutput)
     {
-        ErrorOutput(message);
-    }
-
-    /// <summary>
-    /// Report a warning-level message via <see cref="Output"/>.
-    /// </summary>
-    public static void ReportWarning(string message)
-    {
-        Output(message);
+        errorOutput(message);
     }
 
     // ─── Scope callback errors ───────────────────────────────────────
@@ -108,7 +90,8 @@ public static class ErrorReporter
     public static void ReportWaiterCallbackException(
         string implType,
         string requestor,
-        Exception ex
+        Exception ex,
+        Action<string> errorOutput
     )
     {
         var sb = new StringBuilder()
@@ -116,7 +99,7 @@ public static class ErrorReporter
             .AppendLine($"  Impl Type: {implType}")
             .AppendLine($"  Requestor: {requestor}")
             .AppendLine($"  Exception: {ex}");
-        ErrorOutput(sb.ToString());
+        errorOutput(sb.ToString());
     }
 
     public static void ReportResolveDependencyCallbackException(
@@ -124,7 +107,8 @@ public static class ErrorReporter
         string requestor,
         string scopeChain,
         string depChain,
-        Exception ex
+        Exception ex,
+        Action<string> errorOutput
     )
     {
         var sb = new StringBuilder()
@@ -134,14 +118,14 @@ public static class ErrorReporter
             .AppendLine($"  Scope Chain: {scopeChain}")
             .AppendLine($"  Dependency Chain: {depChain}")
             .AppendLine($"  Exception: {ex}");
-        ErrorOutput(sb.ToString());
+        errorOutput(sb.ToString());
     }
 
     // ─── Scope errors ────────────────────────────────────────────────
 
-    public static void ReportParentScopeNotFound(string typeName)
+    public static void ReportParentScopeNotFound(string typeName, Action<string> errorOutput)
     {
-        ErrorOutput($"[GodotSharpDI] {typeName}: Cannot find parent Scope in scene tree.");
+        errorOutput($"[GodotSharpDI] {typeName}: Cannot find parent Scope in scene tree.");
     }
 
     public static void ReportServiceNotFound(
@@ -149,7 +133,8 @@ public static class ErrorReporter
         string exposedType,
         string requestor,
         string scopeChain,
-        string depChain
+        string depChain,
+        Action<string> errorOutput
     )
     {
         var sb = new StringBuilder()
@@ -160,7 +145,7 @@ public static class ErrorReporter
             .AppendLine($"  Requestor: {requestor}")
             .AppendLine($"  Scope Chain: {scopeChain}")
             .AppendLine($"  Dependency Chain: {depChain}");
-        ErrorOutput(sb.ToString());
+        errorOutput(sb.ToString());
     }
 
     public static void ReportServiceError(
@@ -170,7 +155,8 @@ public static class ErrorReporter
         string implType,
         string requestor,
         string scopeChain,
-        string depChain
+        string depChain,
+        Action<string> errorOutput
     )
     {
         var sb = new StringBuilder()
@@ -181,6 +167,6 @@ public static class ErrorReporter
             .AppendLine($"  Requestor: {requestor}")
             .AppendLine($"  Scope Chain: {scopeChain}")
             .AppendLine($"  Dependency Chain: {depChain}");
-        ErrorOutput(sb.ToString());
+        errorOutput(sb.ToString());
     }
 }

--- a/GodotSharpDI.Runtime/ErrorReporter.cs
+++ b/GodotSharpDI.Runtime/ErrorReporter.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Diagnostics;
 using System.Text;
+using Godot;
 
 namespace GodotSharpDI.Runtime;
 
@@ -12,65 +12,77 @@ namespace GodotSharpDI.Runtime;
 public static class ErrorReporter
 {
     /// <summary>
-    /// Warning-level output callback. Defaults to <see cref="System.Diagnostics.Debug.WriteLine(string)"/>.
-    /// Users can override this to redirect warnings (e.g., to Godot's GD.PushWarning).
+    /// Warning-level output callback. Defaults to <see cref="Godot.GD.PushWarning(object?[])"/>.
+    /// Users can override this to redirect warnings.
     /// </summary>
-    public static Action<string> Output { get; set; } = msg => Debug.WriteLine(msg);
+    internal static Action<string> Output { get; set; } = GD.PushWarning;
 
     /// <summary>
-    /// Error-level output callback. Defaults to <see cref="System.Diagnostics.Debug.WriteLine(string)"/>.
-    /// Users can override this to redirect errors (e.g., to Godot's GD.PrintErr).
+    /// Error-level output callback. Defaults to <see cref="Godot.GD.PrintErr(object?[])"/>.
+    /// Users can override this to redirect errors.
     /// </summary>
-    public static Action<string> ErrorOutput { get; set; } = msg => Debug.WriteLine(msg);
+    internal static Action<string> ErrorOutput { get; set; } = GD.PrintErr;
 
     // ─── Injection errors ────────────────────────────────────────────
 
     public static void ReportInjectionAssignFailed(
-        string typeName, string memberName, string memberType, string exMsg)
+        string typeName,
+        string memberName,
+        string memberType,
+        Exception ex
+    )
     {
         var sb = new StringBuilder()
             .AppendLine("[GodotSharpDI] Failed to assign injected value.")
             .AppendLine($"  Type: {typeName}")
             .AppendLine($"  Member: {memberName}")
             .AppendLine($"  Member Type: {memberType}")
-            .AppendLine($"  Exception: {exMsg}");
-        Output(sb.ToString());
+            .AppendLine($"  Exception: {ex}");
+        ErrorOutput(sb.ToString());
     }
 
     public static void ReportInjectionReadyCallbackFailed(
-        string typeName, string memberName, string memberType, string exMsg)
+        string typeName,
+        string memberName,
+        string memberType,
+        Exception ex
+    )
     {
         var sb = new StringBuilder()
             .AppendLine("[GodotSharpDI] OnXxxInjectionReady callback threw an exception.")
             .AppendLine($"  Type: {typeName}")
             .AppendLine($"  Member: {memberName}")
             .AppendLine($"  Member Type: {memberType}")
-            .AppendLine($"  Exception: {exMsg}");
+            .AppendLine($"  Exception: {ex}");
         ErrorOutput(sb.ToString());
     }
 
     public static void ReportInjectionFailedCallbackFailed(
-        string typeName, string memberName, string memberType, string exMsg)
+        string typeName,
+        string memberName,
+        string memberType,
+        Exception ex
+    )
     {
         var sb = new StringBuilder()
             .AppendLine("[GodotSharpDI] OnXxxInjectionFailed callback threw an exception.")
             .AppendLine($"  Type: {typeName}")
             .AppendLine($"  Member: {memberName}")
             .AppendLine($"  Member Type: {memberType}")
-            .AppendLine($"  Exception: {exMsg}");
-        Output(sb.ToString());
+            .AppendLine($"  Exception: {ex}");
+        ErrorOutput(sb.ToString());
     }
 
     // ─── Provider errors ─────────────────────────────────────────────
 
-    public static void ReportProviderThrew(string implType, string exMsg)
+    public static void ReportProviderThrew(string implType, Exception ex)
     {
-        Output($"[GodotSharpDI] Provider for {implType} threw: {exMsg}");
+        ErrorOutput($"[GodotSharpDI] Provider for {implType} threw: {ex}");
     }
 
-    public static void ReportAsyncProviderThrew(string implType, string exMsg)
+    public static void ReportAsyncProviderThrew(string implType, Exception ex)
     {
-        Output($"[GodotSharpDI] Async provider for {implType} threw: {exMsg}");
+        ErrorOutput($"[GodotSharpDI] Async provider for {implType} threw: {ex}");
     }
 
     // ─── Convenience methods ──────────────────────────────────────────
@@ -91,34 +103,84 @@ public static class ErrorReporter
         Output(message);
     }
 
+    // ─── Scope callback errors ───────────────────────────────────────
+
+    public static void ReportWaiterCallbackException(
+        string implType,
+        string requestor,
+        Exception ex
+    )
+    {
+        var sb = new StringBuilder()
+            .AppendLine("[GodotSharpDI] Exception in dependency injection callback")
+            .AppendLine($"  Impl Type: {implType}")
+            .AppendLine($"  Requestor: {requestor}")
+            .AppendLine($"  Exception: {ex}");
+        ErrorOutput(sb.ToString());
+    }
+
+    public static void ReportResolveDependencyCallbackException(
+        string exposedType,
+        string requestor,
+        string scopeChain,
+        string depChain,
+        Exception ex
+    )
+    {
+        var sb = new StringBuilder()
+            .AppendLine("[GodotSharpDI] Exception in dependency injection callback")
+            .AppendLine($"  Exposed Type: {exposedType}")
+            .AppendLine($"  Requestor: {requestor}")
+            .AppendLine($"  Scope Chain: {scopeChain}")
+            .AppendLine($"  Dependency Chain: {depChain}")
+            .AppendLine($"  Exception: {ex}");
+        ErrorOutput(sb.ToString());
+    }
+
     // ─── Scope errors ────────────────────────────────────────────────
 
-    public static string BuildServiceNotFoundMessage(
-        string scopeName, string exposedType, string requestor, string scopeChain, string depChain)
+    public static void ReportParentScopeNotFound(string typeName)
     {
-        return new StringBuilder()
+        ErrorOutput($"[GodotSharpDI] {typeName}: Cannot find parent Scope in scene tree.");
+    }
+
+    public static void ReportServiceNotFound(
+        string scopeName,
+        string exposedType,
+        string requestor,
+        string scopeChain,
+        string depChain
+    )
+    {
+        var sb = new StringBuilder()
             .AppendLine($"[GodotSharpDI] Cannot find service {exposedType}")
             .AppendLine("  Reason: No Scope in scene tree contains this service")
             .AppendLine($"  Scope: {scopeName}")
             .AppendLine($"  Impl Type: N/A")
             .AppendLine($"  Requestor: {requestor}")
             .AppendLine($"  Scope Chain: {scopeChain}")
-            .AppendLine($"  Dependency Chain: {depChain}")
-            .ToString();
+            .AppendLine($"  Dependency Chain: {depChain}");
+        ErrorOutput(sb.ToString());
     }
 
-    public static string BuildServiceErrorMessage(
-        string title, string reason, string scopeName,
-        string implType, string requestor, string scopeChain, string depChain)
+    public static void ReportServiceError(
+        string title,
+        string reason,
+        string scopeName,
+        string implType,
+        string requestor,
+        string scopeChain,
+        string depChain
+    )
     {
-        return new StringBuilder()
+        var sb = new StringBuilder()
             .AppendLine($"[GodotSharpDI] {title}")
             .AppendLine($"  Reason: {reason}")
             .AppendLine($"  Scope: {scopeName}")
             .AppendLine($"  Impl Type: {implType}")
             .AppendLine($"  Requestor: {requestor}")
             .AppendLine($"  Scope Chain: {scopeChain}")
-            .AppendLine($"  Dependency Chain: {depChain}")
-            .ToString();
+            .AppendLine($"  Dependency Chain: {depChain}");
+        ErrorOutput(sb.ToString());
     }
 }

--- a/GodotSharpDI.Runtime/GodotSharpDI.Runtime.csproj
+++ b/GodotSharpDI.Runtime/GodotSharpDI.Runtime.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="GodotSharpDI.Runtime.Tests" />
     <InternalsVisibleTo Include="GodotSharpDI.SourceGenerator.Tests" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="GodotSharp" Version="4.6.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GodotSharpDI.Abstractions\GodotSharpDI.Abstractions.csproj" />

--- a/GodotSharpDI.Runtime/GodotSharpDI.Runtime.csproj
+++ b/GodotSharpDI.Runtime/GodotSharpDI.Runtime.csproj
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="GodotSharpDI.Runtime.Tests" />
+    <InternalsVisibleTo Include="GodotSharpDI.SourceGenerator.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="GodotSharp" Version="4.6.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GodotSharpDI.Abstractions\GodotSharpDI.Abstractions.csproj" />

--- a/GodotSharpDI.Runtime/InjectionExecutor.cs
+++ b/GodotSharpDI.Runtime/InjectionExecutor.cs
@@ -59,7 +59,7 @@ public static class InjectionExecutor
             catch (Exception ex)
             {
                 ErrorReporter.ReportInjectionAssignFailed(
-                    typeName, memberName, typeof(T).Name, ex.Message);
+                    typeName, memberName, typeof(T).Name, ex);
             }
 
             // Separate try-catch for ready callback (only if assign succeeded)
@@ -72,7 +72,7 @@ public static class InjectionExecutor
                 catch (Exception ex)
                 {
                     ErrorReporter.ReportInjectionReadyCallbackFailed(
-                        typeName, memberName, typeof(T).Name, ex.Message);
+                        typeName, memberName, typeof(T).Name, ex);
                 }
             }
         }
@@ -86,7 +86,7 @@ public static class InjectionExecutor
             catch (Exception ex)
             {
                 ErrorReporter.ReportInjectionFailedCallbackFailed(
-                    typeName, memberName, typeof(T).Name, ex.Message);
+                    typeName, memberName, typeof(T).Name, ex);
             }
         }
 

--- a/GodotSharpDI.Runtime/InjectionExecutor.cs
+++ b/GodotSharpDI.Runtime/InjectionExecutor.cs
@@ -36,6 +36,7 @@ public static class InjectionExecutor
     /// </param>
     /// <param name="typeName">The containing type name, for error reporting.</param>
     /// <param name="memberName">The member name, for error reporting.</param>
+    /// <param name="errorOutput">Error output callback. Typically <c>GD.PrintErr</c>.</param>
     public static void Execute<T>(
         Action<T> assign,
         T? value,
@@ -44,7 +45,8 @@ public static class InjectionExecutor
         List<Action<bool>> callbackList,
         Action onDependencyResolved,
         string typeName,
-        string memberName) where T : class
+        string memberName,
+        Action<string> errorOutput) where T : class
     {
         var assignSucceeded = false;
 
@@ -59,7 +61,7 @@ public static class InjectionExecutor
             catch (Exception ex)
             {
                 ErrorReporter.ReportInjectionAssignFailed(
-                    typeName, memberName, typeof(T).Name, ex);
+                    typeName, memberName, typeof(T).Name, ex, errorOutput);
             }
 
             // Separate try-catch for ready callback (only if assign succeeded)
@@ -72,7 +74,7 @@ public static class InjectionExecutor
                 catch (Exception ex)
                 {
                     ErrorReporter.ReportInjectionReadyCallbackFailed(
-                        typeName, memberName, typeof(T).Name, ex);
+                        typeName, memberName, typeof(T).Name, ex, errorOutput);
                 }
             }
         }
@@ -86,7 +88,7 @@ public static class InjectionExecutor
             catch (Exception ex)
             {
                 ErrorReporter.ReportInjectionFailedCallbackFailed(
-                    typeName, memberName, typeof(T).Name, ex);
+                    typeName, memberName, typeof(T).Name, ex, errorOutput);
             }
         }
 

--- a/GodotSharpDI.Runtime/SyncProviderRunner.cs
+++ b/GodotSharpDI.Runtime/SyncProviderRunner.cs
@@ -20,10 +20,12 @@ public static class SyncProviderRunner
     /// Registration callback. Typically <c>(inst, pt) => scope.ProvideService&lt;T&gt;(inst, pt)</c>
     /// </param>
     /// <param name="providerType">The provider type name, for diagnostics.</param>
+    /// <param name="errorOutput">Error output callback. Typically <c>GD.PrintErr</c>.</param>
     public static void Run<T>(
         Func<T> factory,
         Action<T?, string> provide,
-        string providerType) where T : class
+        string providerType,
+        Action<string> errorOutput) where T : class
     {
         try
         {
@@ -32,7 +34,7 @@ public static class SyncProviderRunner
         }
         catch (Exception ex)
         {
-            ErrorReporter.ReportProviderThrew(typeof(T).Name, ex);
+            ErrorReporter.ReportProviderThrew(typeof(T).Name, ex, errorOutput);
             provide(null, providerType);
         }
     }

--- a/GodotSharpDI.Runtime/SyncProviderRunner.cs
+++ b/GodotSharpDI.Runtime/SyncProviderRunner.cs
@@ -32,7 +32,7 @@ public static class SyncProviderRunner
         }
         catch (Exception ex)
         {
-            ErrorReporter.ReportProviderThrew(typeof(T).Name, ex.Message);
+            ErrorReporter.ReportProviderThrew(typeof(T).Name, ex);
             provide(null, providerType);
         }
     }

--- a/GodotSharpDI.Runtime/WaitForCoordinator.cs
+++ b/GodotSharpDI.Runtime/WaitForCoordinator.cs
@@ -9,6 +9,9 @@ namespace GodotSharpDI.Runtime;
 /// Coordinates WaitFor dependency resolution for a single [Provide] member.
 /// Replaces the lambda + ContinueWith pattern in WaitForPhase.GenerateForMember.
 ///
+/// Godot-specific operations (Callable.From, GD.PrintErr) are injected as delegates
+/// to keep this class compatible with netstandard2.0.
+///
 /// Thread Safety: <see cref="_remaining"/> uses <see cref="Interlocked.Decrement"/>
 /// because callbacks may fire from background threads (e.g. async providers).
 /// </summary>
@@ -40,6 +43,9 @@ public class WaitForCoordinator
     /// </param>
     /// <param name="depName">The dependency member name, for error reporting.</param>
     /// <param name="memberName">The Provide member name, for error reporting.</param>
+    /// <param name="errorOutput">
+    /// Error reporting callback. Typically <c>msg => GD.PrintErr(msg)</c>.
+    /// </param>
     /// <param name="dispatchToMainThread">
     /// Main-thread dispatcher. Typically <c>action => Callable.From(action).CallDeferred()</c>.
     /// </param>
@@ -47,6 +53,7 @@ public class WaitForCoordinator
         List<Action<bool>> callbackList,
         string depName,
         string memberName,
+        Action<string> errorOutput,
         Action<Action> dispatchToMainThread)
     {
         callbackList.Add(ok =>
@@ -54,7 +61,8 @@ public class WaitForCoordinator
             if (!ok)
             {
                 ErrorReporter.ReportError(
-                    $"[GodotSharpDI] WaitFor: dependency '{depName}' for '{memberName}' failed");
+                    $"[GodotSharpDI] WaitFor: dependency '{depName}' for '{memberName}' failed",
+                    errorOutput);
             }
 
             if (Interlocked.Decrement(ref _remaining) == 0)
@@ -66,7 +74,8 @@ public class WaitForCoordinator
                         var ex = t.Exception?.GetBaseException();
                         dispatchToMainThread(() =>
                             ErrorReporter.ReportError(
-                                $"[GodotSharpDI] WaitFor callback threw: {ex}"));
+                                $"[GodotSharpDI] WaitFor callback threw: {ex}",
+                                errorOutput));
                     }
                 }, TaskScheduler.Default);
             }

--- a/GodotSharpDI.Runtime/WaitForCoordinator.cs
+++ b/GodotSharpDI.Runtime/WaitForCoordinator.cs
@@ -9,9 +9,6 @@ namespace GodotSharpDI.Runtime;
 /// Coordinates WaitFor dependency resolution for a single [Provide] member.
 /// Replaces the lambda + ContinueWith pattern in WaitForPhase.GenerateForMember.
 ///
-/// Godot-specific operations (Callable.From, GD.PrintErr) are injected as delegates
-/// to keep this class compatible with netstandard2.0.
-///
 /// Thread Safety: <see cref="_remaining"/> uses <see cref="Interlocked.Decrement"/>
 /// because callbacks may fire from background threads (e.g. async providers).
 /// </summary>
@@ -43,9 +40,6 @@ public class WaitForCoordinator
     /// </param>
     /// <param name="depName">The dependency member name, for error reporting.</param>
     /// <param name="memberName">The Provide member name, for error reporting.</param>
-    /// <param name="reportError">
-    /// Error reporting callback. Typically <c>msg => GD.PrintErr(msg)</c>.
-    /// </param>
     /// <param name="dispatchToMainThread">
     /// Main-thread dispatcher. Typically <c>action => Callable.From(action).CallDeferred()</c>.
     /// </param>
@@ -53,14 +47,13 @@ public class WaitForCoordinator
         List<Action<bool>> callbackList,
         string depName,
         string memberName,
-        Action<string> reportError,
         Action<Action> dispatchToMainThread)
     {
         callbackList.Add(ok =>
         {
             if (!ok)
             {
-                reportError(
+                ErrorReporter.ReportError(
                     $"[GodotSharpDI] WaitFor: dependency '{depName}' for '{memberName}' failed");
             }
 
@@ -70,10 +63,10 @@ public class WaitForCoordinator
                 {
                     if (t.IsFaulted)
                     {
-                        var errMsg = t.Exception?.GetBaseException().Message;
+                        var ex = t.Exception?.GetBaseException();
                         dispatchToMainThread(() =>
-                            reportError(
-                                $"[GodotSharpDI] WaitFor callback threw: {errMsg}"));
+                            ErrorReporter.ReportError(
+                                $"[GodotSharpDI] WaitFor callback threw: {ex}"));
                     }
                 }, TaskScheduler.Default);
             }

--- a/GodotSharpDI.Sample/GameManager.cs
+++ b/GodotSharpDI.Sample/GameManager.cs
@@ -48,10 +48,7 @@ public sealed partial class GameManager : Node, IGameState, IDependenciesResolve
     //   Wait for _playerStatsCenter injection to complete (success or failure) before calling this method.
     // This ensures _playerStatsCenter can be safely used in GetPlayerStatsService().
 
-    [Provide(
-        ExposedTypes = [typeof(IPlayerStats)],
-        WaitFor = [nameof(_playerStatsCenter)]
-    )]
+    [Provide(ExposedTypes = [typeof(IPlayerStats)], WaitFor = [nameof(_playerStatsCenter)])]
     public async Task<PlayerStatsService> GetPlayerStatsService()
     {
         // Asynchronously create service instance, waits for _playerStatsCenter injection to complete before executing

--- a/GodotSharpDI.SourceGenerator.Tests/AssemblyAttributes.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/AssemblyAttributes.cs
@@ -1,0 +1,5 @@
+using Xunit;
+
+// All test classes in this project share the global ErrorReporter static state,
+// so parallel execution causes cross-test interference.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/GodotSharpDI.SourceGenerator.Tests/E2E/BasicInjectionTests.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/E2E/BasicInjectionTests.cs
@@ -16,10 +16,7 @@ public class BasicInjectionTests
     [Fact]
     public void BasicSyncProvide_InjectsIntoUser()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -52,41 +49,36 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            // Instantiate scope and host
-            var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
-            var host = E2ETestHelper.Instantiate(asm, "Test.MyHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
+        // Instantiate scope and host
+        var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
+        var host = E2ETestHelper.Instantiate(asm, "Test.MyHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
 
-            // Wire parent: host→scope, user→scope
-            E2ETestHelper.WireParent(host, scope);
-            E2ETestHelper.WireParent(user, scope);
+        // Wire parent: host→scope, user→scope
+        E2ETestHelper.WireParent(host, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            // Trigger lifecycle: EnterTree → Ready
-            E2ETestHelper.Notify(host, 10); // EnterTree
-            E2ETestHelper.Notify(host, 13); // Ready → ProvideServices + ResolveDependencies
-            E2ETestHelper.Notify(user, 10); // EnterTree
-            E2ETestHelper.Notify(user, 13); // Ready → ResolveDependencies
+        // Trigger lifecycle: EnterTree → Ready
+        E2ETestHelper.Notify(host, 10); // EnterTree
+        E2ETestHelper.Notify(host, 13); // Ready → ProvideServices + ResolveDependencies
+        E2ETestHelper.Notify(user, 10); // EnterTree
+        E2ETestHelper.Notify(user, 13); // Ready → ResolveDependencies
 
-            // Verify: _service should be injected
-            var serviceValue = E2ETestHelper.GetFieldValue(user, "_service");
-            Assert.NotNull(serviceValue);
+        // Verify: _service should be injected
+        var serviceValue = E2ETestHelper.GetFieldValue(user, "_service");
+        Assert.NotNull(serviceValue);
 
-            // Verify it's the right type
-            var valueProp = serviceValue!.GetType().GetProperty("Value");
-            Assert.Equal("hello", valueProp!.GetValue(serviceValue));
-        }
-        finally { restore(); }
+        // Verify it's the right type
+        var valueProp = serviceValue!.GetType().GetProperty("Value");
+        Assert.Equal("hello", valueProp!.GetValue(serviceValue));
     }
 
     [Fact]
     public void MethodProvider_InjectsIntoUser()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -119,33 +111,28 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.AppScope");
-            var host = E2ETestHelper.Instantiate(asm, "Test.ConfigHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.App");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.AppScope");
+        var host = E2ETestHelper.Instantiate(asm, "Test.ConfigHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.App");
 
-            E2ETestHelper.WireParent(host, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(host, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(host, 10);
-            E2ETestHelper.Notify(host, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(host, 10);
+        E2ETestHelper.Notify(host, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            var config = E2ETestHelper.GetFieldValue(user, "_config");
-            Assert.NotNull(config);
-        }
-        finally { restore(); }
+        var config = E2ETestHelper.GetFieldValue(user, "_config");
+        Assert.NotNull(config);
     }
 
     [Fact]
     public void MultipleServices_AllInjected()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -184,33 +171,28 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.MultiScope");
-            var host = E2ETestHelper.Instantiate(asm, "Test.MultiHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.MultiUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.MultiScope");
+        var host = E2ETestHelper.Instantiate(asm, "Test.MultiHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.MultiUser");
 
-            E2ETestHelper.WireParent(host, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(host, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(host, 10);
-            E2ETestHelper.Notify(host, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(host, 10);
+        E2ETestHelper.Notify(host, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_a"));
-            Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_b"));
-        }
-        finally { restore(); }
+        Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_a"));
+        Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_b"));
     }
 
     [Fact]
     public void HostSelfExposure_Works()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -242,34 +224,29 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.GameScope");
-            var host = E2ETestHelper.Instantiate(asm, "Test.GameHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.GameUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.GameScope");
+        var host = E2ETestHelper.Instantiate(asm, "Test.GameHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.GameUser");
 
-            E2ETestHelper.WireParent(host, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(host, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(host, 10);
-            E2ETestHelper.Notify(host, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(host, 10);
+        E2ETestHelper.Notify(host, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            var injectedHost = E2ETestHelper.GetFieldValue(user, "_host");
-            Assert.NotNull(injectedHost);
-            Assert.Same(host, injectedHost);
-        }
-        finally { restore(); }
+        var injectedHost = E2ETestHelper.GetFieldValue(user, "_host");
+        Assert.NotNull(injectedHost);
+        Assert.Same(host, injectedHost);
     }
 
     [Fact]
     public void TwoHosts_CrossInjection_Works()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -314,27 +291,25 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.CrossScope");
-            var hostA = E2ETestHelper.Instantiate(asm, "Test.HostA");
-            var hostB = E2ETestHelper.Instantiate(asm, "Test.HostB");
-            var user = E2ETestHelper.Instantiate(asm, "Test.CrossUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.CrossScope");
+        var hostA = E2ETestHelper.Instantiate(asm, "Test.HostA");
+        var hostB = E2ETestHelper.Instantiate(asm, "Test.HostB");
+        var user = E2ETestHelper.Instantiate(asm, "Test.CrossUser");
 
-            E2ETestHelper.WireParent(hostA, scope);
-            E2ETestHelper.WireParent(hostB, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(hostA, scope);
+        E2ETestHelper.WireParent(hostB, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(hostA, 10);
-            E2ETestHelper.Notify(hostA, 13);
-            E2ETestHelper.Notify(hostB, 10);
-            E2ETestHelper.Notify(hostB, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(hostA, 10);
+        E2ETestHelper.Notify(hostA, 13);
+        E2ETestHelper.Notify(hostB, 10);
+        E2ETestHelper.Notify(hostB, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_x"));
-            Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_y"));
-        }
-        finally { restore(); }
+        Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_x"));
+        Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_y"));
     }
 }

--- a/GodotSharpDI.SourceGenerator.Tests/E2E/BasicInjectionTests.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/E2E/BasicInjectionTests.cs
@@ -13,21 +13,10 @@ namespace GodotSharpDI.SourceGenerator.Tests.E2E;
 /// </summary>
 public class BasicInjectionTests
 {
-    private static (List<string> errors, List<string> warnings, Action restore) CaptureErrorReporter()
-    {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () => { ErrorReporter.ErrorOutput = prevError; ErrorReporter.Output = prevOutput; });
-    }
-
     [Fact]
     public void BasicSyncProvide_InjectsIntoUser()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"
@@ -94,7 +83,7 @@ namespace Test
     [Fact]
     public void MethodProvider_InjectsIntoUser()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"
@@ -153,7 +142,7 @@ namespace Test
     [Fact]
     public void MultipleServices_AllInjected()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"
@@ -218,7 +207,7 @@ namespace Test
     [Fact]
     public void HostSelfExposure_Works()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"
@@ -277,7 +266,7 @@ namespace Test
     [Fact]
     public void TwoHosts_CrossInjection_Works()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"

--- a/GodotSharpDI.SourceGenerator.Tests/E2E/CallbackTests.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/E2E/CallbackTests.cs
@@ -12,21 +12,10 @@ namespace GodotSharpDI.SourceGenerator.Tests.E2E;
 /// </summary>
 public class CallbackTests
 {
-    private static (List<string> errors, List<string> warnings, Action restore) CaptureErrorReporter()
-    {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () => { ErrorReporter.ErrorOutput = prevError; ErrorReporter.Output = prevOutput; });
-    }
-
     [Fact]
     public void ReadyCallback_FiresOnSuccessfulInjection()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"
@@ -97,7 +86,7 @@ namespace Test
     [Fact]
     public void FailureCallback_FiresWhenProviderFails()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"
@@ -167,7 +156,7 @@ namespace Test
     [Fact]
     public void IDependenciesResolved_CalledAfterAllInjections()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"

--- a/GodotSharpDI.SourceGenerator.Tests/E2E/CallbackTests.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/E2E/CallbackTests.cs
@@ -15,10 +15,7 @@ public class CallbackTests
     [Fact]
     public void ReadyCallback_FiresOnSuccessfulInjection()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -57,39 +54,34 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
-            var host = E2ETestHelper.Instantiate(asm, "Test.MyHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
+        var host = E2ETestHelper.Instantiate(asm, "Test.MyHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
 
-            E2ETestHelper.WireParent(host, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(host, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(host, 10);
-            E2ETestHelper.Notify(host, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(host, 10);
+        E2ETestHelper.Notify(host, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            // Verify injection succeeded
-            var service = E2ETestHelper.GetFieldValue(user, "_service");
-            Assert.NotNull(service);
+        // Verify injection succeeded
+        var service = E2ETestHelper.GetFieldValue(user, "_service");
+        Assert.NotNull(service);
 
-            // Verify ReadyCallback fired with the correct value
-            var lastReady = E2ETestHelper.GetPropertyValue(user, "LastReadyValue");
-            Assert.NotNull(lastReady);
-            Assert.Same(service, lastReady);
-        }
-        finally { restore(); }
+        // Verify ReadyCallback fired with the correct value
+        var lastReady = E2ETestHelper.GetPropertyValue(user, "LastReadyValue");
+        Assert.NotNull(lastReady);
+        Assert.Same(service, lastReady);
     }
 
     [Fact]
     public void FailureCallback_FiresWhenProviderFails()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -128,38 +120,33 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
-            var host = E2ETestHelper.Instantiate(asm, "Test.FailingHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
+        var host = E2ETestHelper.Instantiate(asm, "Test.FailingHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
 
-            E2ETestHelper.WireParent(host, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(host, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(host, 10);
-            E2ETestHelper.Notify(host, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(host, 10);
+        E2ETestHelper.Notify(host, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            // Verify injection failed (provider threw)
-            var service = E2ETestHelper.GetFieldValue(user, "_service");
-            Assert.Null(service);
+        // Verify injection failed (provider threw)
+        var service = E2ETestHelper.GetFieldValue(user, "_service");
+        Assert.Null(service);
 
-            // Verify FailureCallback fired
-            var fired = E2ETestHelper.GetPropertyValue(user, "FailureCallbackFired");
-            Assert.Equal(true, fired);
-        }
-        finally { restore(); }
+        // Verify FailureCallback fired
+        var fired = E2ETestHelper.GetPropertyValue(user, "FailureCallbackFired");
+        Assert.Equal(true, fired);
     }
 
     [Fact]
     public void IDependenciesResolved_CalledAfterAllInjections()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -204,28 +191,26 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
-            var host = E2ETestHelper.Instantiate(asm, "Test.MyHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
+        var host = E2ETestHelper.Instantiate(asm, "Test.MyHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
 
-            E2ETestHelper.WireParent(host, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(host, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(host, 10);
-            E2ETestHelper.Notify(host, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(host, 10);
+        E2ETestHelper.Notify(host, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            // Verify both injections succeeded
-            Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_a"));
-            Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_b"));
+        // Verify both injections succeeded
+        Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_a"));
+        Assert.NotNull(E2ETestHelper.GetFieldValue(user, "_b"));
 
-            // Verify OnDependenciesResolved was called exactly once
-            var count = E2ETestHelper.GetPropertyValue(user, "ResolvedCallCount");
-            Assert.Equal(1, count);
-        }
-        finally { restore(); }
+        // Verify OnDependenciesResolved was called exactly once
+        var count = E2ETestHelper.GetPropertyValue(user, "ResolvedCallCount");
+        Assert.Equal(1, count);
     }
 }

--- a/GodotSharpDI.SourceGenerator.Tests/E2E/WaitForTests.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/E2E/WaitForTests.cs
@@ -17,10 +17,7 @@ public class WaitForTests
     [Fact]
     public void WaitFor_SingleDep_ServiceProvidedAfterInjection()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -72,47 +69,42 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
-            var configHost = E2ETestHelper.Instantiate(asm, "Test.ConfigHost");
-            var serviceHost = E2ETestHelper.Instantiate(asm, "Test.ServiceHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
+        var configHost = E2ETestHelper.Instantiate(asm, "Test.ConfigHost");
+        var serviceHost = E2ETestHelper.Instantiate(asm, "Test.ServiceHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
 
-            E2ETestHelper.WireParent(configHost, scope);
-            E2ETestHelper.WireParent(serviceHost, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(configHost, scope);
+        E2ETestHelper.WireParent(serviceHost, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            // ConfigHost lifecycle
-            E2ETestHelper.Notify(configHost, 10);
-            E2ETestHelper.Notify(configHost, 13);
+        // ConfigHost lifecycle
+        E2ETestHelper.Notify(configHost, 10);
+        E2ETestHelper.Notify(configHost, 13);
 
-            // ServiceHost lifecycle (has Inject + Provide with WaitFor)
-            E2ETestHelper.Notify(serviceHost, 10);
-            E2ETestHelper.Notify(serviceHost, 13);
+        // ServiceHost lifecycle (has Inject + Provide with WaitFor)
+        E2ETestHelper.Notify(serviceHost, 10);
+        E2ETestHelper.Notify(serviceHost, 13);
 
-            // User lifecycle
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        // User lifecycle
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            // Verify injection succeeded
-            var service = E2ETestHelper.GetFieldValue(user, "_service");
-            Assert.NotNull(service);
+        // Verify injection succeeded
+        var service = E2ETestHelper.GetFieldValue(user, "_service");
+        Assert.NotNull(service);
 
-            // Verify the service was built with the injected config
-            var configName = service!.GetType().GetProperty("ConfigName")!.GetValue(service);
-            Assert.Equal("prod", configName);
-        }
-        finally { restore(); }
+        // Verify the service was built with the injected config
+        var configName = service!.GetType().GetProperty("ConfigName")!.GetValue(service);
+        Assert.Equal("prod", configName);
     }
 
     [Fact]
     public void WaitFor_MultipleDeps_AllResolvedBeforeProviding()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -175,42 +167,37 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
-            var configHost = E2ETestHelper.Instantiate(asm, "Test.ConfigHost");
-            var loggerHost = E2ETestHelper.Instantiate(asm, "Test.LoggerHost");
-            var serviceHost = E2ETestHelper.Instantiate(asm, "Test.ServiceHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
+        var configHost = E2ETestHelper.Instantiate(asm, "Test.ConfigHost");
+        var loggerHost = E2ETestHelper.Instantiate(asm, "Test.LoggerHost");
+        var serviceHost = E2ETestHelper.Instantiate(asm, "Test.ServiceHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
 
-            E2ETestHelper.WireParent(configHost, scope);
-            E2ETestHelper.WireParent(loggerHost, scope);
-            E2ETestHelper.WireParent(serviceHost, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(configHost, scope);
+        E2ETestHelper.WireParent(loggerHost, scope);
+        E2ETestHelper.WireParent(serviceHost, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(configHost, 10);
-            E2ETestHelper.Notify(configHost, 13);
-            E2ETestHelper.Notify(loggerHost, 10);
-            E2ETestHelper.Notify(loggerHost, 13);
-            E2ETestHelper.Notify(serviceHost, 10);
-            E2ETestHelper.Notify(serviceHost, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(configHost, 10);
+        E2ETestHelper.Notify(configHost, 13);
+        E2ETestHelper.Notify(loggerHost, 10);
+        E2ETestHelper.Notify(loggerHost, 13);
+        E2ETestHelper.Notify(serviceHost, 10);
+        E2ETestHelper.Notify(serviceHost, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            // Verify injection succeeded
-            var service = E2ETestHelper.GetFieldValue(user, "_service");
-            Assert.NotNull(service);
-        }
-        finally { restore(); }
+        // Verify injection succeeded
+        var service = E2ETestHelper.GetFieldValue(user, "_service");
+        Assert.NotNull(service);
     }
 
     [Fact]
     public void WaitFor_FailedDep_StillProvides()
     {
-        var (_, _, restore) = ErrorReporterHelper.Capture();
-        try
-        {
-            var source = @"
+        var source = @"
 using GodotSharpDI.Abstractions;
 using Godot;
 
@@ -256,29 +243,27 @@ namespace Test
     }
 }";
 
-            var asm = E2ETestHelper.GenerateAndCompile(source);
+        var asm = E2ETestHelper.GenerateAndCompile(source);
 
-            var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
-            var failingHost = E2ETestHelper.Instantiate(asm, "Test.FailingDepHost");
-            var serviceHost = E2ETestHelper.Instantiate(asm, "Test.ServiceHost");
-            var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
+        var scope = E2ETestHelper.Instantiate(asm, "Test.MyScope");
+        var failingHost = E2ETestHelper.Instantiate(asm, "Test.FailingDepHost");
+        var serviceHost = E2ETestHelper.Instantiate(asm, "Test.ServiceHost");
+        var user = E2ETestHelper.Instantiate(asm, "Test.MyUser");
 
-            E2ETestHelper.WireParent(failingHost, scope);
-            E2ETestHelper.WireParent(serviceHost, scope);
-            E2ETestHelper.WireParent(user, scope);
+        E2ETestHelper.WireParent(failingHost, scope);
+        E2ETestHelper.WireParent(serviceHost, scope);
+        E2ETestHelper.WireParent(user, scope);
 
-            E2ETestHelper.Notify(failingHost, 10);
-            E2ETestHelper.Notify(failingHost, 13);
-            E2ETestHelper.Notify(serviceHost, 10);
-            E2ETestHelper.Notify(serviceHost, 13);
-            E2ETestHelper.Notify(user, 10);
-            E2ETestHelper.Notify(user, 13);
+        E2ETestHelper.Notify(failingHost, 10);
+        E2ETestHelper.Notify(failingHost, 13);
+        E2ETestHelper.Notify(serviceHost, 10);
+        E2ETestHelper.Notify(serviceHost, 13);
+        E2ETestHelper.Notify(user, 10);
+        E2ETestHelper.Notify(user, 13);
 
-            // WaitForCoordinator fires even when a dep fails.
-            // The service should still be provided (with null dep).
-            var service = E2ETestHelper.GetFieldValue(user, "_service");
-            Assert.NotNull(service);
-        }
-        finally { restore(); }
+        // WaitForCoordinator fires even when a dep fails.
+        // The service should still be provided (with null dep).
+        var service = E2ETestHelper.GetFieldValue(user, "_service");
+        Assert.NotNull(service);
     }
 }

--- a/GodotSharpDI.SourceGenerator.Tests/E2E/WaitForTests.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/E2E/WaitForTests.cs
@@ -14,21 +14,10 @@ namespace GodotSharpDI.SourceGenerator.Tests.E2E;
 /// </summary>
 public class WaitForTests
 {
-    private static (List<string> errors, List<string> warnings, Action restore) CaptureErrorReporter()
-    {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () => { ErrorReporter.ErrorOutput = prevError; ErrorReporter.Output = prevOutput; });
-    }
-
     [Fact]
     public void WaitFor_SingleDep_ServiceProvidedAfterInjection()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"
@@ -120,7 +109,7 @@ namespace Test
     [Fact]
     public void WaitFor_MultipleDeps_AllResolvedBeforeProviding()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"
@@ -218,7 +207,7 @@ namespace Test
     [Fact]
     public void WaitFor_FailedDep_StillProvides()
     {
-        var (_, _, restore) = CaptureErrorReporter();
+        var (_, _, restore) = ErrorReporterHelper.Capture();
         try
         {
             var source = @"

--- a/GodotSharpDI.SourceGenerator.Tests/Helpers/ErrorReporterHelper.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/Helpers/ErrorReporterHelper.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using GodotSharpDI.Runtime;
+
+namespace GodotSharpDI.SourceGenerator.Tests.Helpers;
+
+public static class ErrorReporterHelper
+{
+    public static (List<string> errors, List<string> warnings, Action restore) Capture()
+    {
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        var prevError = ErrorReporter.ErrorOutput;
+        var prevOutput = ErrorReporter.Output;
+        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
+        ErrorReporter.Output = msg => warnings.Add(msg);
+        return (errors, warnings, () =>
+        {
+            ErrorReporter.ErrorOutput = prevError;
+            ErrorReporter.Output = prevOutput;
+        });
+    }
+}

--- a/GodotSharpDI.SourceGenerator.Tests/Helpers/ErrorReporterHelper.cs
+++ b/GodotSharpDI.SourceGenerator.Tests/Helpers/ErrorReporterHelper.cs
@@ -1,23 +1,12 @@
 using System;
 using System.Collections.Generic;
-using GodotSharpDI.Runtime;
 
 namespace GodotSharpDI.SourceGenerator.Tests.Helpers;
 
 public static class ErrorReporterHelper
 {
-    public static (List<string> errors, List<string> warnings, Action restore) Capture()
+    public static Action<string> CreateErrorCollector(List<string> errors)
     {
-        var errors = new List<string>();
-        var warnings = new List<string>();
-        var prevError = ErrorReporter.ErrorOutput;
-        var prevOutput = ErrorReporter.Output;
-        ErrorReporter.ErrorOutput = msg => errors.Add(msg);
-        ErrorReporter.Output = msg => warnings.Add(msg);
-        return (errors, warnings, () =>
-        {
-            ErrorReporter.ErrorOutput = prevError;
-            ErrorReporter.Output = prevOutput;
-        });
+        return msg => errors.Add(msg);
     }
 }

--- a/GodotSharpDI.SourceGenerator/Analyzers/GeneratedMemberAccessAnalyzer.cs
+++ b/GodotSharpDI.SourceGenerator/Analyzers/GeneratedMemberAccessAnalyzer.cs
@@ -20,42 +20,46 @@ public sealed class GeneratedMemberAccessAnalyzer : DiagnosticAnalyzer
     /// List of method names that are forbidden to call manually
     /// </summary>
     private static readonly ImmutableHashSet<string> ForbiddenMethodNames = ImmutableHashSet.Create(
-        // Service factory methods
-        "CreateService",
-        // Node DI generated private methods
-        "GetServiceScope",
-        "AttachToScope",
-        "UnattachToScope",
-        // User generated private methods
-        "ResolveUserDependencies",
-        "OnDependencyResolved",
-        // Host generated private methods
-        "AttachHostServices",
-        "UnattachHostServices",
-        // Scope generated private methods
+        // Node lifecycle (all roles)
         "GetParentScope",
-        "InstantiateScopeSingletons",
-        "DisposeScopeSingletons",
-        "CheckWaitList",
-        // Scope implemented IScope methods
-        "ResolveDependency",
-        "RegisterService",
-        "UnregisterService"
+        "ResetInjectionState",
+        // Host lifecycle
+        "ProvideServices",
+        "ResolveDependencies",
+        // User lifecycle
+        // (ResolveDependencies shared with Host)
+        // Scope lifecycle
+        "StartDependencyMonitoring",
+        "StopDependencyMonitoring",
+        "CheckPendingDependencies",
+        "ReportUnresolvedDependencies",
+        // Injection callback
+        "OnDependencyResolved",
+        // Scope static initializers
+        "CreateServiceCache",
+        "CreateServiceImplementationMap",
+        "CreateDeadlockDetector",
+        // Scope IScope interface methods
+        "ProvideService",
+        "ResolveDependency"
     );
 
     /// <summary>
     /// List of field names that are forbidden to access manually
     /// </summary>
     private static readonly ImmutableHashSet<string> ForbiddenFieldNames = ImmutableHashSet.Create(
-        // Node DI generated fields
+        // Node lifecycle (Host/User)
         "__parentScope",
-        // Scope generated fields
-        "ServiceTypes",
-        "_services",
+        // Async provider cancellation (Host/User)
+        "__lifetime_cancellation_tokens",
+        // Injection dependency tracking (Host/User with IDependenciesResolved)
+        "__unresolvedDependencies",
+        // Scope service container
+        "ServiceImplementationMap",
+        "ServiceCache",
         "_waiters",
-        "_disposableSingletons",
-        // User IDependenciesResolved generated fields
-        "__unresolvedDependencies"
+        "_deadlockDetector",
+        "_dependencyCheckTimer"
     );
 
     /// <summary>
@@ -525,9 +529,8 @@ public sealed class GeneratedMemberAccessAnalyzer : DiagnosticAnalyzer
             if (!SymbolEqualityComparer.Default.Equals(interfaceType, cachedSymbols.IScope))
                 return false;
 
-            return methodName == "ResolveDependency"
-                || methodName == "RegisterService"
-                || methodName == "UnregisterService";
+            return methodName == "ProvideService"
+                || methodName == "ResolveDependency";
         }
         catch
         {

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/HostGenerator.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/HostGenerator.cs
@@ -85,8 +85,9 @@ internal static class HostGenerator
             f.AppendLine($"if ({GlobalNames.LocalScope} is null)");
             f.BeginBlock();
             {
-                f.PrintError(
-                    $"\"[GodotSharpDI] {validatedType.Symbol.Name}: Cannot find parent Scope in scene tree.\""
+                f.AppendLine(
+                    $"{GlobalNames.ErrorReporter}.ReportParentScopeNotFound("
+                    + $"\"{validatedType.Symbol.Name}\");"
                 );
                 f.AppendLine("return;");
             }

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/HostGenerator.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/HostGenerator.cs
@@ -87,7 +87,8 @@ internal static class HostGenerator
             {
                 f.AppendLine(
                     $"{GlobalNames.ErrorReporter}.ReportParentScopeNotFound("
-                    + $"\"{validatedType.Symbol.Name}\");"
+                    + $"\"{validatedType.Symbol.Name}\","
+                    + $" {GlobalNames.GodotGD}.PrintErr);"
                 );
                 f.AppendLine("return;");
             }

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/NodeLifeCycleGenerator.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/NodeLifeCycleGenerator.cs
@@ -37,13 +37,6 @@ internal static class NodeLifeCycleGenerator
         GenerateNotification(f, validatedType);
     }
 
-    private static void GenerateErrorReporterInit(CodeFormatter f)
-    {
-        f.AppendLine(
-            $"{GlobalNames.ErrorReporter}.ErrorOutput = {GlobalNames.GodotGD}.PrintErr;",
-            "Initialize ErrorReporter to use Godot error output");
-    }
-
     private static void GenerateParentScopeField(CodeFormatter f)
     {
         f.AppendHiddenMemberCommentAndAttribute();
@@ -96,7 +89,6 @@ internal static class NodeLifeCycleGenerator
                 f.AppendLine("case NotificationEnterTree:");
                 f.BeginBlock();
                 {
-                    GenerateErrorReporterInit(f);
                     f.AppendLine("__parentScope = null;");
                     if (validatedType.Role == TypeRole.Host || validatedType.Role == TypeRole.User)
                     {

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/ScopeInterfaceGenerator.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/ScopeInterfaceGenerator.cs
@@ -90,7 +90,8 @@ internal static class ScopeInterfaceGenerator
                 $"{GlobalNames.ErrorReporter}.ReportServiceError("
                 + "\"Host cannot provide service\","
                 + "\"No Scope in scene tree contains implementation type: \" + implType.Name,"
-                + "providerType, implType.Name, \"-\", \"-\", \"-\");"
+                + "providerType, implType.Name, \"-\", \"-\", \"-\","
+                + $" {GlobalNames.GodotGD}.PrintErr);"
             );
             f.AppendLine("return;");
         }
@@ -114,7 +115,8 @@ internal static class ScopeInterfaceGenerator
             $"{GlobalNames.ErrorReporter}.ReportServiceError("
             + "\"Host failed to provide service\","
             + "\"Null reference provided for implementation type: \" + implType.Name,"
-            + "providerType, implType.Name, \"-\", \"-\", \"-\");"
+            + "providerType, implType.Name, \"-\", \"-\", \"-\","
+            + $" {GlobalNames.GodotGD}.PrintErr);"
         );
         f.AppendLine();
         f.AppendLine("// Notify waiting waiters: service creation failed, pass null to callback");
@@ -132,7 +134,8 @@ internal static class ScopeInterfaceGenerator
                 {
                     f.AppendLine(
                         $"{GlobalNames.ErrorReporter}.ReportWaiterCallbackException("
-                        + "implType.Name, waiter.RequestorType, ex);"
+                        + "implType.Name, waiter.RequestorType, ex,"
+                        + $" {GlobalNames.GodotGD}.PrintErr);"
                     );
                 }
                 f.EndTryCatch();
@@ -153,7 +156,8 @@ internal static class ScopeInterfaceGenerator
                 $"{GlobalNames.ErrorReporter}.ReportServiceError("
                 + "\"Duplicate service provision\","
                 + "\"Service \" + implType.Name + \" has already been provided\","
-                + "\"-\", implType.Name, \"-\", \"-\", \"-\");"
+                + "\"-\", implType.Name, \"-\", \"-\", \"-\","
+                + $" {GlobalNames.GodotGD}.PrintErr);"
             );
             f.AppendLine("return;");
         }
@@ -180,7 +184,8 @@ internal static class ScopeInterfaceGenerator
                 {
                     f.AppendLine(
                         $"{GlobalNames.ErrorReporter}.ReportWaiterCallbackException("
-                        + "implType.Name, waiter.RequestorType, ex);"
+                        + "implType.Name, waiter.RequestorType, ex,"
+                        + $" {GlobalNames.GodotGD}.PrintErr);"
                     );
                 }
                 f.EndTryCatch();
@@ -259,7 +264,8 @@ internal static class ScopeInterfaceGenerator
         f.AppendLine(
             $"{GlobalNames.ErrorReporter}.ReportServiceNotFound("
             + $"\"{validatedType.Symbol.Name}\", exposedType.Name, requestorType,"
-            + "currentScopeChain, currentDependencyChain);"
+            + "currentScopeChain, currentDependencyChain,"
+            + $" {GlobalNames.GodotGD}.PrintErr);"
         );
         f.AppendLine();
 
@@ -271,7 +277,8 @@ internal static class ScopeInterfaceGenerator
         {
             f.AppendLine(
                 $"{GlobalNames.ErrorReporter}.ReportResolveDependencyCallbackException("
-                + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex);"
+                + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex,"
+                + $" {GlobalNames.GodotGD}.PrintErr);"
             );
         }
         f.EndTryCatch();
@@ -300,7 +307,8 @@ internal static class ScopeInterfaceGenerator
                         + "\"Type mismatch in dependency injection\","
                         + "\"Service implementation type \" + implType.Name + \" cannot be cast to \" + exposedType.Name,"
                         + $"\"{validatedType.Symbol.Name}\", implType.Name, requestorType,"
-                        + "currentScopeChain, currentDependencyChain);"
+                        + "currentScopeChain, currentDependencyChain,"
+                        + $" {GlobalNames.GodotGD}.PrintErr);"
                     );
                     f.AppendLine("onResult.Invoke(null);");
                 }
@@ -310,7 +318,8 @@ internal static class ScopeInterfaceGenerator
             {
                 f.AppendLine(
                     $"{GlobalNames.ErrorReporter}.ReportResolveDependencyCallbackException("
-                    + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex);"
+                    + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex,"
+                    + $" {GlobalNames.GodotGD}.PrintErr);"
                 );
             }
             f.EndTryCatch();
@@ -329,7 +338,8 @@ internal static class ScopeInterfaceGenerator
                 + "\"Previous creation of service \" + exposedType.Name + \" failed\","
                 + "\"The Host reported a null instance\","
                 + $"\"{validatedType.Symbol.Name}\", exposedType.Name, requestorType,"
-                + "currentScopeChain, currentDependencyChain);"
+                + "currentScopeChain, currentDependencyChain,"
+                + $" {GlobalNames.GodotGD}.PrintErr);"
             );
             f.AppendLine();
 
@@ -341,7 +351,8 @@ internal static class ScopeInterfaceGenerator
             {
                 f.AppendLine(
                     $"{GlobalNames.ErrorReporter}.ReportResolveDependencyCallbackException("
-                    + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex);"
+                    + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex,"
+                    + $" {GlobalNames.GodotGD}.PrintErr);"
                 );
             }
             f.EndTryCatch();
@@ -365,7 +376,7 @@ internal static class ScopeInterfaceGenerator
             f.AppendLine();
 
             f.BeginDebugRegion();
-            f.AppendLine($"_deadlockDetector.TrackAndDetect(requestorType, exposedType.Name);");
+            f.AppendLine($"_deadlockDetector.TrackAndDetect(requestorType, exposedType.Name, {GlobalNames.GodotGD}.PrintErr);");
             f.EndDebugRegion();
             f.AppendLine();
 

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/ScopeInterfaceGenerator.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/ScopeInterfaceGenerator.cs
@@ -86,9 +86,11 @@ internal static class ScopeInterfaceGenerator
             }
             f.EndBlock();
             f.AppendLine();
-            f.PrintError(
-                "$\"[GodotSharpDI] Host '{providerType}' cannot provide service"
-                + "\\n  Reason: No Scope in scene tree contains implementation type: {implType.Name}\""
+            f.AppendLine(
+                $"{GlobalNames.ErrorReporter}.ReportServiceError("
+                + "\"Host cannot provide service\","
+                + "\"No Scope in scene tree contains implementation type: \" + implType.Name,"
+                + "providerType, implType.Name, \"-\", \"-\", \"-\");"
             );
             f.AppendLine("return;");
         }
@@ -108,9 +110,11 @@ internal static class ScopeInterfaceGenerator
         f.EndBlock();
         f.AppendLine($"cacheEntry.State = {GlobalNames.ServiceState}.Failed;");
         f.AppendLine();
-        f.PrintError(
-            "$\"[GodotSharpDI] Host '{providerType}' failed to provide service"
-            + "\\n  Reason: Null reference provided for implementation type: {implType.Name}\""
+        f.AppendLine(
+            $"{GlobalNames.ErrorReporter}.ReportServiceError("
+            + "\"Host failed to provide service\","
+            + "\"Null reference provided for implementation type: \" + implType.Name,"
+            + "providerType, implType.Name, \"-\", \"-\", \"-\");"
         );
         f.AppendLine();
         f.AppendLine("// Notify waiting waiters: service creation failed, pass null to callback");
@@ -126,9 +130,9 @@ internal static class ScopeInterfaceGenerator
                 }
                 f.CatchBlock("ex");
                 {
-                    f.PrintError(
-                        "$\"[GodotSharpDI] Exception in dependency injection callback (on failure)"
-                        + "\\n  Reason: {ex.Message}\""
+                    f.AppendLine(
+                        $"{GlobalNames.ErrorReporter}.ReportWaiterCallbackException("
+                        + "implType.Name, waiter.RequestorType, ex);"
                     );
                 }
                 f.EndTryCatch();
@@ -145,9 +149,11 @@ internal static class ScopeInterfaceGenerator
         f.AppendLine($"if (cacheEntry.State == {GlobalNames.ServiceState}.Created)");
         f.BeginBlock();
         {
-            f.PrintError(
-                "$\"[GodotSharpDI] Duplicate service provision"
-                + "\\n  Reason: Service {implType.Name} has already been provided\""
+            f.AppendLine(
+                $"{GlobalNames.ErrorReporter}.ReportServiceError("
+                + "\"Duplicate service provision\","
+                + "\"Service \" + implType.Name + \" has already been provided\","
+                + "\"-\", implType.Name, \"-\", \"-\", \"-\");"
             );
             f.AppendLine("return;");
         }
@@ -172,9 +178,9 @@ internal static class ScopeInterfaceGenerator
                 }
                 f.CatchBlock("ex");
                 {
-                    f.PrintError(
-                        "$\"[GodotSharpDI] Exception in dependency injection callback"
-                        + "\\n  Reason: {ex.Message}\""
+                    f.AppendLine(
+                        $"{GlobalNames.ErrorReporter}.ReportWaiterCallbackException("
+                        + "implType.Name, waiter.RequestorType, ex);"
                     );
                 }
                 f.EndTryCatch();
@@ -250,13 +256,10 @@ internal static class ScopeInterfaceGenerator
         f.EndBlock();
         f.AppendLine();
 
-        f.PrintError(
-            "$\"[GodotSharpDI] Cannot find service {exposedType.Name}"
-            + "\\n  Reason: No Scope in scene tree contains this service"
-            + $"\\n  Scope: {validatedType.Symbol.Name}"
-            + "\\n  Requestor: {requestorType}"
-            + "\\n  Scope Chain: {currentScopeChain}"
-            + "\\n  Dependency Chain: {currentDependencyChain}\""
+        f.AppendLine(
+            $"{GlobalNames.ErrorReporter}.ReportServiceNotFound("
+            + $"\"{validatedType.Symbol.Name}\", exposedType.Name, requestorType,"
+            + "currentScopeChain, currentDependencyChain);"
         );
         f.AppendLine();
 
@@ -266,9 +269,9 @@ internal static class ScopeInterfaceGenerator
         }
         f.CatchBlock("ex");
         {
-            f.PrintError(
-                "$\"[GodotSharpDI] Exception in dependency injection callback"
-                + "\\n  Reason: {ex.Message}\""
+            f.AppendLine(
+                $"{GlobalNames.ErrorReporter}.ReportResolveDependencyCallbackException("
+                + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex);"
             );
         }
         f.EndTryCatch();
@@ -292,13 +295,12 @@ internal static class ScopeInterfaceGenerator
                 f.AppendLine("else");
                 f.BeginBlock();
                 {
-                    f.PrintError(
-                        "$\"[GodotSharpDI] Type mismatch in dependency injection"
-                        + "\\n  Reason: Service implementation type {implType.Name} cannot be cast to {exposedType.Name}"
-                        + $"\\n  Scope: {validatedType.Symbol.Name}"
-                        + "\\n  Requestor: {requestorType}"
-                        + "\\n  Scope Chain: {currentScopeChain}"
-                        + "\\n  Dependency Chain: {currentDependencyChain}\""
+                    f.AppendLine(
+                        $"{GlobalNames.ErrorReporter}.ReportServiceError("
+                        + "\"Type mismatch in dependency injection\","
+                        + "\"Service implementation type \" + implType.Name + \" cannot be cast to \" + exposedType.Name,"
+                        + $"\"{validatedType.Symbol.Name}\", implType.Name, requestorType,"
+                        + "currentScopeChain, currentDependencyChain);"
                     );
                     f.AppendLine("onResult.Invoke(null);");
                 }
@@ -306,9 +308,9 @@ internal static class ScopeInterfaceGenerator
             }
             f.CatchBlock("ex");
             {
-                f.PrintError(
-                    "$\"[GodotSharpDI] Exception in dependency injection callback"
-                    + "\\n  Reason: {ex.Message}\""
+                f.AppendLine(
+                    $"{GlobalNames.ErrorReporter}.ReportResolveDependencyCallbackException("
+                    + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex);"
                 );
             }
             f.EndTryCatch();
@@ -322,13 +324,12 @@ internal static class ScopeInterfaceGenerator
         f.AppendLine($"case {GlobalNames.ServiceState}.Failed:");
         f.BeginBlock();
         {
-            f.PrintError(
-                "$\"[GodotSharpDI] Previous creation of service {exposedType.Name} failed"
-                + "\\n  Reason: The Host reported a null instance"
-                + $"\\n  Scope: {validatedType.Symbol.Name}"
-                + "\\n  Requestor: {requestorType}"
-                + "\\n  Scope Chain: {currentScopeChain}"
-                + "\\n  Dependency Chain: {currentDependencyChain}\""
+            f.AppendLine(
+                $"{GlobalNames.ErrorReporter}.ReportServiceError("
+                + "\"Previous creation of service \" + exposedType.Name + \" failed\","
+                + "\"The Host reported a null instance\","
+                + $"\"{validatedType.Symbol.Name}\", exposedType.Name, requestorType,"
+                + "currentScopeChain, currentDependencyChain);"
             );
             f.AppendLine();
 
@@ -338,9 +339,9 @@ internal static class ScopeInterfaceGenerator
             }
             f.CatchBlock("ex");
             {
-                f.PrintError(
-                    "$\"[GodotSharpDI] Exception in dependency injection callback"
-                    + "\\n  Reason: {ex.Message}\""
+                f.AppendLine(
+                    $"{GlobalNames.ErrorReporter}.ReportResolveDependencyCallbackException("
+                    + "exposedType.Name, requestorType, currentScopeChain, currentDependencyChain, ex);"
                 );
             }
             f.EndTryCatch();

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/InjectionGenerator.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/InjectionGenerator.cs
@@ -279,7 +279,8 @@ internal static class InjectionGenerator
             {
                 f.AppendLine(
                     $"{GlobalNames.ErrorReporter}.ReportParentScopeNotFound("
-                    + $"\"{validatedType.Symbol.Name}\");"
+                    + $"\"{validatedType.Symbol.Name}\","
+                    + $" {GlobalNames.GodotGD}.PrintErr);"
                 );
                 f.AppendLine("return;");
             }
@@ -344,7 +345,8 @@ internal static class InjectionGenerator
                 f.AppendLine("() => { },");
 
             f.AppendLine($"\"{validatedType.Symbol.Name}\",");
-            f.AppendLine($"\"{memberName}\");");
+            f.AppendLine($"\"{memberName}\",");
+            f.AppendLine($"{GlobalNames.GodotGD}.PrintErr);");
         }
         f.EndLevel();
     }

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/InjectionGenerator.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/InjectionGenerator.cs
@@ -277,8 +277,9 @@ internal static class InjectionGenerator
             f.AppendLine($"if ({GlobalNames.LocalScope} is null)");
             f.BeginBlock();
             {
-                f.PrintError(
-                    $"$\"[GodotSharpDI] {validatedType.Symbol.Name}: Cannot find parent Scope in scene tree.\""
+                f.AppendLine(
+                    $"{GlobalNames.ErrorReporter}.ReportParentScopeNotFound("
+                    + $"\"{validatedType.Symbol.Name}\");"
                 );
                 f.AppendLine("return;");
             }

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/ServiceProvisionPhase.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/ServiceProvisionPhase.cs
@@ -88,6 +88,7 @@ internal static class ServiceProvisionPhase
                 f.AppendLine($"(inst, pt) => scope.ProvideService<{implType}>(inst, pt),");
                 f.AppendLine($"\"{providerTypeName}\",");
                 f.AppendLine("ct,");
+                f.AppendLine($"{GlobalNames.GodotGD}.PrintErr,");
                 f.AppendLine($"action => {GlobalNames.GodotCallable}.From(action).CallDeferred());");
             }
             f.EndLevel();
@@ -112,7 +113,8 @@ internal static class ServiceProvisionPhase
         {
             f.AppendLine($"() => {memberAccess},");
             f.AppendLine($"(inst, pt) => {scopeField}.ProvideService<{implType}>(inst, pt),");
-            f.AppendLine($"\"{providerTypeName}\");");
+            f.AppendLine($"\"{providerTypeName}\",");
+            f.AppendLine($"{GlobalNames.GodotGD}.PrintErr);");
         }
         f.EndLevel();
     }

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/ServiceProvisionPhase.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/ServiceProvisionPhase.cs
@@ -88,7 +88,6 @@ internal static class ServiceProvisionPhase
                 f.AppendLine($"(inst, pt) => scope.ProvideService<{implType}>(inst, pt),");
                 f.AppendLine($"\"{providerTypeName}\",");
                 f.AppendLine("ct,");
-                f.AppendLine($"{GlobalNames.ErrorReporter}.ErrorOutput,");
                 f.AppendLine($"action => {GlobalNames.GodotCallable}.From(action).CallDeferred());");
             }
             f.EndLevel();

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/WaitForPhase.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/WaitForPhase.cs
@@ -61,7 +61,6 @@ internal static class WaitForPhase
                 $"{coordinatorVar}.Register({listName}, \"{depName}\", \"{memberName}\",");
             f.BeginLevel();
             {
-                f.AppendLine($"{GlobalNames.ErrorReporter}.ErrorOutput,");
                 f.AppendLine($"action => {GlobalNames.GodotCallable}.From(action).CallDeferred());");
             }
             f.EndLevel();

--- a/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/WaitForPhase.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Coding/Shared/WaitForPhase.cs
@@ -61,6 +61,7 @@ internal static class WaitForPhase
                 $"{coordinatorVar}.Register({listName}, \"{depName}\", \"{memberName}\",");
             f.BeginLevel();
             {
+                f.AppendLine($"{GlobalNames.GodotGD}.PrintErr,");
                 f.AppendLine($"action => {GlobalNames.GodotCallable}.From(action).CallDeferred());");
             }
             f.EndLevel();

--- a/GodotSharpDI.SourceGenerator/Internal/Helpers/GeneratorHelper.cs
+++ b/GodotSharpDI.SourceGenerator/Internal/Helpers/GeneratorHelper.cs
@@ -154,7 +154,7 @@ internal static class GeneratorHelper
 
     public static void PrintError(this CodeFormatter f, string target)
     {
-        f.AppendLine($"{GlobalNames.ErrorReporter}.ReportError({target});");
+        f.AppendLine($"{GlobalNames.ErrorReporter}.ReportError({target}, {GlobalNames.GodotGD}.PrintErr);");
     }
 
     public static void AppendTypeConstraints(this CodeFormatter f, string typeConstraints)

--- a/GodotSharpDI/GodotSharpDI.csproj
+++ b/GodotSharpDI/GodotSharpDI.csproj
@@ -8,7 +8,7 @@
     <IsPackable>true</IsPackable>
     <!-- Package Metadata -->
     <PackageId>GodotSharpDI</PackageId>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <Authors>Supheria</Authors>
     <Description>A source generator based dependency injection framework for Godot C# projects. Provides compile-time DI with support for singleton services, constructor and member injection.</Description>
     <PackageTags>godot;dependency-injection;di;source-generator;csharp;dotnet</PackageTags>
@@ -35,37 +35,37 @@
   <!-- Include Generator DLL in analyzers folder -->
   <ItemGroup>
     <None
-      Include="$(OutputPath)/../netstandard2.0/GodotSharpDI.SourceGenerator.dll"
+      Include="..\GodotSharpDI.SourceGenerator\bin\Release\netstandard2.0\GodotSharpDI.SourceGenerator.dll"
       Pack="true"
       PackagePath="analyzers/dotnet/cs"
       Visible="false"
     />
     <None
-      Include="$(OutputPath)/../netstandard2.0/GodotSharpDI.CodeFixes.dll"
+      Include="..\GodotSharpDI.CodeFixes\bin\Release\netstandard2.0\GodotSharpDI.CodeFixes.dll"
       Pack="true"
       PackagePath="analyzers/dotnet/cs"
       Visible="false"
     />
     <None
-      Include="$(OutputPath)/../netstandard2.0/GodotSharpDI.Shared.dll"
+      Include="..\GodotSharpDI.Shared\bin\Release\netstandard2.0\GodotSharpDI.Shared.dll"
       Pack="true"
       PackagePath="analyzers/dotnet/cs"
       Visible="false"
     />
     <None
-      Include="$(OutputPath)/../net8.0/GodotSharpDI.Abstractions.dll"
+      Include="..\GodotSharpDI.Abstractions\bin\Release\netstandard2.0\GodotSharpDI.Abstractions.dll"
       Pack="true"
       PackagePath="lib/net8.0"
       Visible="false"
     />
     <None
-      Include="$(OutputPath)/../net8.0/GodotSharpDI.Runtime.dll"
+      Include="..\GodotSharpDI.Runtime\bin\Release\net8.0\GodotSharpDI.Runtime.dll"
       Pack="true"
       PackagePath="lib/net8.0"
       Visible="false"
     />
     <None
-      Include="$(OutputPath)/../netstandard2.0/zh-hans/GodotSharpDI.Shared.resources.dll"
+      Include="..\GodotSharpDI.Shared\bin\Release\netstandard2.0\zh-hans\GodotSharpDI.Shared.resources.dll"
       Pack="true"
       PackagePath="analyzers/dotnet/cs/zh-hans"
       Visible="false"

--- a/GodotSharpDI/GodotSharpDI.csproj
+++ b/GodotSharpDI/GodotSharpDI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -53,15 +53,15 @@
       Visible="false"
     />
     <None
-      Include="$(OutputPath)/../netstandard2.0/GodotSharpDI.Abstractions.dll"
+      Include="$(OutputPath)/../net8.0/GodotSharpDI.Abstractions.dll"
       Pack="true"
-      PackagePath="lib/netstandard2.0"
+      PackagePath="lib/net8.0"
       Visible="false"
     />
     <None
-      Include="$(OutputPath)/../netstandard2.0/GodotSharpDI.Runtime.dll"
+      Include="$(OutputPath)/../net8.0/GodotSharpDI.Runtime.dll"
       Pack="true"
-      PackagePath="lib/netstandard2.0"
+      PackagePath="lib/net8.0"
       Visible="false"
     />
     <None

--- a/GodotSharpDI/GodotSharpDI.csproj
+++ b/GodotSharpDI/GodotSharpDI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -55,13 +55,13 @@
     <None
       Include="..\GodotSharpDI.Abstractions\bin\Release\netstandard2.0\GodotSharpDI.Abstractions.dll"
       Pack="true"
-      PackagePath="lib/net8.0"
+      PackagePath="lib/netstandard2.0"
       Visible="false"
     />
     <None
-      Include="..\GodotSharpDI.Runtime\bin\Release\net8.0\GodotSharpDI.Runtime.dll"
+      Include="..\GodotSharpDI.Runtime\bin\Release\netstandard2.0\GodotSharpDI.Runtime.dll"
       Pack="true"
-      PackagePath="lib/net8.0"
+      PackagePath="lib/netstandard2.0"
       Visible="false"
     />
     <None

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The core design philosophy of GodotSharpDI is to **merge Godot's scene tree life
 ## Installation
 
 ```xml
-<PackageReference Include="GodotSharpDI" Version="1.4.0" />
+<PackageReference Include="GodotSharpDI" Version="1.4.1" />
 ```
 ⚠️ **Make sure to also add the GodotSharp package to your project**: The generated code depends on Godot.Node and Godot.GD.
 
@@ -918,17 +918,19 @@ Child scopes inherit services from parent scopes but can also override them.
 ```
 1. Node.EnterTree
    ↓
-2. Find parent Scope
+2. Reset injection state (cancel in-flight async ops, clear callback lists)
    ↓
-3. Resolve all [Inject] dependencies concurrently
+3. Node.Ready
+   ↓
+4. Provide all [Provide] services (sync providers run immediately, async providers fire-and-forget)
+   ↓
+5. Resolve all [Inject] dependencies concurrently
    │
    ├─ Dependency A: Success → IsAInjectionReady = true
    ├─ Dependency B: Success → IsBInjectionReady = true
    └─ Dependency C: Failed → IsCInjectionReady = false
    ↓
-4. OnDependenciesResolved() called after all dependencies resolved
-   ↓
-5. Provide all [Provide] services concurrently
+6. OnDependenciesResolved() called after all dependencies resolved
 ```
 
 #### WaitFor Injection Flow (New in 1.1.0)
@@ -936,15 +938,11 @@ Child scopes inherit services from parent scopes but can also override them.
 ```
 1. Node.EnterTree
    ↓
-2. Find parent Scope
+2. Reset injection state (cancel in-flight async ops, clear callback lists)
    ↓
-3. Phase 1: Resolve all [Inject] dependencies concurrently (doesn't block service provision)
-   │
-   ├─ Dependency A: Success → IsAInjectionReady = true
-   ├─ Dependency B: Failed → IsBInjectionReady = false
-   └─ Dependency C: Success → IsCInjectionReady = true
+3. Node.Ready
    ↓
-4. Phase 2: Provide services (independent of dependency injection)
+4. Phase 1: Provide services (independent of dependency injection)
    │
    ├─ Service X (no WaitFor): Provide immediately
    │
@@ -959,7 +957,13 @@ Child scopes inherit services from parent scopes but can also override them.
       └─ All complete → Provide service Z
          (Must check IsBInjectionReady)
    ↓
-5. OnDependenciesResolved() called after all dependencies resolved
+5. Phase 2: Resolve all [Inject] dependencies concurrently
+   │
+   ├─ Dependency A: Success → IsAInjectionReady = true
+   ├─ Dependency B: Failed → IsBInjectionReady = false
+   └─ Dependency C: Success → IsCInjectionReady = true
+   ↓
+6. OnDependenciesResolved() called after all dependencies resolved
 ```
 
 #### Key Concepts
@@ -1027,9 +1031,9 @@ public partial class ExampleHost : Node, IDependenciesResolved
 }
 
 // Timeline:
-// T1: _config starts resolving, _logger starts resolving, CreateMetrics starts providing
-// T2: _config resolution complete → CreateDatabase starts providing
-// T3: both _logger and _config resolution complete → CreateRepository starts providing  
+// T1: CreateMetrics starts providing (ProvideServices in NotificationReady)
+// T2: _config starts resolving, _logger starts resolving (ResolveDependencies)
+// T3: _config resolution complete → CreateDatabase starts providing (WaitFor satisfied)
 // T4: both _config and _logger resolved → OnDependenciesResolved is called
 ```
 
@@ -1546,7 +1550,7 @@ public partial class MyHost : Node, IDependenciesResolved
     // ... other code
 }
 
-// Generated code (in MyHost.DI.Host.g.cs)
+// Generated code (in MyHost.DI.Inject.g.cs)
 partial class MyHost
 {
     // Readiness flag generated for each Inject member
@@ -1560,7 +1564,7 @@ partial class MyHost
     [MemberNotNullWhen(true, nameof(_config))]
     [MemberNotNullWhen(true, nameof(_logger))]
     private bool IsAllDependenciesReady => 
-        IsConfigInjectionReady == true && IsLoggerInjectionReady == true;
+        IsConfigInjectionReady && IsLoggerInjectionReady;
     
     // Unresolved dependency tracking
     private readonly HashSet<Type> __unresolvedDependencies = new()
@@ -1576,6 +1580,44 @@ partial class MyHost
         if (__unresolvedDependencies.Count == 0)
         {
             ((IDependenciesResolved)this).OnDependenciesResolved();
+        }
+    }
+}
+
+// Generated code (in MyHost.DI.Lifecycle.g.cs)
+partial class MyHost
+{
+    private IScope? __parentScope;
+
+    private IScope? GetParentScope()
+    {
+        if (__parentScope is not null) return __parentScope;
+        var parent = GetParent();
+        while (parent is not null)
+        {
+            if (parent is IScope scope) { __parentScope = scope; return __parentScope; }
+            parent = parent.GetParent();
+        }
+        return null;
+    }
+
+    public override partial void _Notification(int what)
+    {
+        base._Notification(what);
+        switch ((long)what)
+        {
+            case NotificationEnterTree:
+                __parentScope = null;
+                ResetInjectionState();
+                break;
+            case NotificationReady:
+                ProvideServices();
+                ResolveDependencies();
+                break;
+            case NotificationExitTree:
+                __parentScope = null;
+                ResetInjectionState();
+                break;
         }
     }
 }
@@ -1738,7 +1780,7 @@ public partial class DataManager : Node, IDependenciesResolved
 `OnDependenciesResolved` is called at the following timing:
 
 1. **All `[Inject]` dependencies have been attempted to resolve** (success or failure)
-2. **After the node's `_Notification(NotificationEnterTree)`**
+2. **After the node's `_Notification(NotificationReady)`**
 3. **Before async `[Provide]` services have necessarily completed initialization** (async providers may still be running when this is called)
 
 #### Best Practices
@@ -1840,20 +1882,32 @@ All generated code is in `*.DI.g.cs` files.
 The framework integrates with Godot's lifecycle through `_Notification`:
 
 ```csharp
+// Generated _Notification for Host/User types:
 public override partial void _Notification(int what)
 {
     base._Notification(what);
     switch ((long)what)
     {
         case NotificationEnterTree:
-            AttachToScope();
+            __parentScope = null;
+            ResetInjectionState();
+            break;
+        case NotificationReady:
+            // Host: ProvideServices() + ResolveDependencies()
+            // User: ResolveDependencies()
             break;
         case NotificationExitTree:
-            DetachFromScope();
+            __parentScope = null;
+            ResetInjectionState();
             break;
     }
 }
 ```
+
+**Lifecycle Phases**:
+- **EnterTree**: Reset injection state — cancel in-flight async providers, clear callback lists, reset ready flags
+- **Ready**: Provide services and resolve dependencies (Host provides first, then both resolve)
+- **ExitTree**: Reset injection state again to abort any pending operations
 
 ---
 
@@ -2090,7 +2144,7 @@ public class EnemyFactory : IEnemyFactory
 
 ## Diagnostic Codes
 
-The framework provides comprehensive compile-time error checking. For a complete list of diagnostic codes, please refer to [AnalyzerReleases.Shipped.md](./GodotSharpDI.SourceGenerator/AnalyzerReleases.Shipped.md).
+The framework provides comprehensive compile-time error checking.
 
 **Diagnostic Code Categories**:
 
@@ -2145,7 +2199,7 @@ public partial class GameManager : Node
     public IGameState Self => this;
 }
 
-// Generated file: GameManager.DI.g.cs (not scanned by Godot)
+// Generated file: GameManager.DI.Lifecycle.g.cs (not scanned by Godot)
 partial class GameManager
 {
     // Framework provides the implementation
@@ -2155,10 +2209,16 @@ partial class GameManager
         switch ((long)what)
         {
             case NotificationEnterTree:
-                AttachToScope();
+                __parentScope = null;
+                ResetInjectionState();
+                break;
+            case NotificationReady:
+                ProvideServices();
+                ResolveDependencies();
                 break;
             case NotificationExitTree:
-                UnattachToScope();
+                __parentScope = null;
+                ResetInjectionState();
                 break;
         }
     }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -73,7 +73,7 @@ GodotSharpDI 的核心设计理念是**将 Godot 的场景树生命周期与传�
 ## 安装
 
 ```xml
-<PackageReference Include="GodotSharpDI" Version="1.4.0" />
+<PackageReference Include="GodotSharpDI" Version="1.4.1" />
 ```
 ⚠️ **确保项目中同时添加了 GodotSharp 软件包**：生成的代码依赖 Godot.Node 和 Godot.GD。
 
@@ -918,17 +918,19 @@ RootScope
 ```
 1. Node.EnterTree
    ↓
-2. 查找父 Scope
+2. 重置注入状态（取消进行中的异步操作，清空回调列表）
    ↓
-3. 并发解析所有 [Inject] 依赖
+3. Node.Ready
+   ↓
+4. 提供所有 [Provide] 服务（同步 provider 立即执行，异步 provider fire-and-forget）
+   ↓
+5. 并发解析所有 [Inject] 依赖
    │
    ├─ 依赖 A: 成功 → IsAInjectionReady = true
    ├─ 依赖 B: 成功 → IsBInjectionReady = true
    └─ 依赖 C: 失败 → IsCInjectionReady = false
    ↓
-4. 所有依赖解析完成后调用 OnDependenciesResolved()
-   ↓
-5. 并发提供所有 [Provide] 服务
+6. 所有依赖解析完成后调用 OnDependenciesResolved()
 ```
 
 #### WaitFor 注入流程（1.1.0 新增）
@@ -936,15 +938,11 @@ RootScope
 ```
 1. Node.EnterTree
    ↓
-2. 查找父 Scope
+2. 重置注入状态（取消进行中的异步操作，清空回调列表）
    ↓
-3. 阶段 1: 并发解析所有 [Inject] 依赖（不阻塞服务提供）
-   │
-   ├─ 依赖 A: 成功 → IsAInjectionReady = true
-   ├─ 依赖 B: 失败 → IsBInjectionReady = false
-   └─ 依赖 C: 成功 → IsCInjectionReady = true
+3. Node.Ready
    ↓
-4. 阶段 2: 提供服务（独立于依赖注入）
+4. 阶段 1: 提供服务（独立于依赖注入）
    │
    ├─ 服务 X (无 WaitFor): 立即提供
    │
@@ -959,7 +957,13 @@ RootScope
       └─ 全部完成后 → 提供服务 Z
          （需检查 IsBInjectionReady）
    ↓
-5. 所有依赖解析完成后调用 OnDependenciesResolved()
+5. 阶段 2: 并发解析所有 [Inject] 依赖
+   │
+   ├─ 依赖 A: 成功 → IsAInjectionReady = true
+   ├─ 依赖 B: 失败 → IsBInjectionReady = false
+   └─ 依赖 C: 成功 → IsCInjectionReady = true
+   ↓
+6. 所有依赖解析完成后调用 OnDependenciesResolved()
 ```
 
 #### 关键概念
@@ -1027,9 +1031,9 @@ public partial class ExampleHost : Node, IDependenciesResolved
 }
 
 // 时间线：
-// T1: _config 开始解析, _logger 开始解析, CreateMetrics 开始提供
-// T2: _config 解析完成 → CreateDatabase 开始提供
-// T3: _logger 和 _config 都解析完成 → CreateRepository 开始提供  
+// T1: CreateMetrics 开始提供（NotificationReady 中 ProvideServices 执行）
+// T2: _config 开始解析, _logger 开始解析（ResolveDependencies 执行）
+// T3: _config 解析完成 → CreateDatabase 开始提供（WaitFor 满足）
 // T4: _config 和 _logger 都解析完成 → OnDependenciesResolved 被调用
 ```
 
@@ -1546,7 +1550,7 @@ public partial class MyHost : Node, IDependenciesResolved
     // ... 其他代码
 }
 
-// 生成的代码（在 MyHost.DI.Host.g.cs 中）
+// 生成的代码（在 MyHost.DI.Inject.g.cs 中）
 partial class MyHost
 {
     // 为每个 Inject 成员生成的就绪标志
@@ -1560,7 +1564,7 @@ partial class MyHost
     [MemberNotNullWhen(true, nameof(_config))]
     [MemberNotNullWhen(true, nameof(_logger))]
     private bool IsAllDependenciesReady => 
-        IsConfigInjectionReady == true && IsLoggerInjectionReady == true;
+        IsConfigInjectionReady && IsLoggerInjectionReady;
     
     // 未解析依赖追踪
     private readonly HashSet<Type> __unresolvedDependencies = new()
@@ -1576,6 +1580,44 @@ partial class MyHost
         if (__unresolvedDependencies.Count == 0)
         {
             ((IDependenciesResolved)this).OnDependenciesResolved();
+        }
+    }
+}
+
+// 生成的代码（在 MyHost.DI.Lifecycle.g.cs 中）
+partial class MyHost
+{
+    private IScope? __parentScope;
+
+    private IScope? GetParentScope()
+    {
+        if (__parentScope is not null) return __parentScope;
+        var parent = GetParent();
+        while (parent is not null)
+        {
+            if (parent is IScope scope) { __parentScope = scope; return __parentScope; }
+            parent = parent.GetParent();
+        }
+        return null;
+    }
+
+    public override partial void _Notification(int what)
+    {
+        base._Notification(what);
+        switch ((long)what)
+        {
+            case NotificationEnterTree:
+                __parentScope = null;
+                ResetInjectionState();
+                break;
+            case NotificationReady:
+                ProvideServices();
+                ResolveDependencies();
+                break;
+            case NotificationExitTree:
+                __parentScope = null;
+                ResetInjectionState();
+                break;
         }
     }
 }
@@ -1738,8 +1780,8 @@ public partial class DataManager : Node, IDependenciesResolved
 `OnDependenciesResolved` 在以下时机被调用：
 
 1. **所有 `[Inject]` 依赖都已尝试解析**（成功或失败）
-2. **在节点的 `_Notification(NotificationEnterTree)` 之后**
-3. **在任何 `[Provide]` 服务被实际使用之前**
+2. **在节点的 `_Notification(NotificationReady)` 之后**
+3. **在异步 `[Provide]` 服务完成初始化之前**（异步 provider 可能仍在运行）
 
 #### 最佳实践
 
@@ -1840,20 +1882,32 @@ public partial class MyHost : Node
 框架通过 `_Notification` 与 Godot 的生命周期集成：
 
 ```csharp
+// Host/User 类型生成的 _Notification：
 public override partial void _Notification(int what)
 {
     base._Notification(what);
     switch ((long)what)
     {
         case NotificationEnterTree:
-            AttachToScope();
+            __parentScope = null;
+            ResetInjectionState();
+            break;
+        case NotificationReady:
+            // Host: ProvideServices() + ResolveDependencies()
+            // User: ResolveDependencies()
             break;
         case NotificationExitTree:
-            DetachFromScope();
+            __parentScope = null;
+            ResetInjectionState();
             break;
     }
 }
 ```
+
+**生命周期阶段**：
+- **EnterTree**：重置注入状态 — 取消进行中的异步 provider，清空回调列表，重置就绪标志
+- **Ready**：提供服务并解析依赖（Host 先提供再解析，User 仅解析）
+- **ExitTree**：再次重置注入状态，中止所有待处理操作
 
 ---
 
@@ -2090,7 +2144,7 @@ public class EnemyFactory : IEnemyFactory
 
 ## 诊断代码
 
-框架提供全面的编译时错误检查。完整的诊断代码列表，请参考 [AnalyzerReleases.Shipped.md](./GodotSharpDI.SourceGenerator/AnalyzerReleases.Shipped.md)。
+框架提供全面的编译时错误检查。
 
 **诊断代码类别**：
 
@@ -2145,7 +2199,7 @@ public partial class GameManager : Node
     public IGameState Self => this;
 }
 
-// 生成的文件：GameManager.DI.g.cs（Godot 不扫描）
+// 生成的文件：GameManager.DI.Lifecycle.g.cs（Godot 不扫描）
 partial class GameManager
 {
     // 框架提供实现
@@ -2155,10 +2209,16 @@ partial class GameManager
         switch ((long)what)
         {
             case NotificationEnterTree:
-                AttachToScope();
+                __parentScope = null;
+                ResetInjectionState();
+                break;
+            case NotificationReady:
+                ProvideServices();
+                ResolveDependencies();
                 break;
             case NotificationExitTree:
-                DetachFromScope();
+                __parentScope = null;
+                ResetInjectionState();
                 break;
         }
     }

--- a/nuget-build.bat
+++ b/nuget-build.bat
@@ -11,7 +11,14 @@ if exist %OUTPUT% rmdir /s /q %OUTPUT%
 
 echo.
 echo Cleaning previous builds...
-dotnet clean %PROJECT%
+dotnet clean GodotSharpDI.sln -c Release
+
+echo.
+echo Removing bin/obj directories...
+for %%p in (GodotSharpDI GodotSharpDI.SourceGenerator GodotSharpDI.CodeFixes GodotSharpDI.Shared GodotSharpDI.Abstractions GodotSharpDI.Runtime) do (
+    if exist %%p\bin rmdir /s /q %%p\bin
+    if exist %%p\obj rmdir /s /q %%p\obj
+)
 
 echo.
 echo Packing...

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,48 @@
+======
+v1.4.1
+======
+
+BUG FIXES
+---------
+
+1. Callback exception error messages now include RequestorType
+2. NuGet package could contain stale DLLs due to incorrect path references
+   in GodotSharpDI.csproj
+
+
+BREAKING CHANGES
+----------------
+
+1. ErrorReporter API refactored
+   - Removed Output / ErrorOutput static fields
+   - Removed ReportWarning method
+   - All Report* methods accept Exception instead of string exMsg,
+     and Action<string> errorOutput as the last parameter
+   - BuildServiceNotFoundMessage / BuildServiceErrorMessage replaced by
+     ReportServiceNotFound / ReportServiceError
+   - New methods: ReportParentScopeNotFound, ReportWaiterCallbackException,
+     ReportResolveDependencyCallbackException, ReportError
+
+2. Runtime class method signatures updated
+   The following runtime classes now require an Action<string> errorOutput
+   parameter for error reporting (previously used ErrorReporter static fields):
+     - AsyncProviderRunner.Run
+     - SyncProviderRunner.Run
+     - InjectionExecutor.Execute
+     - WaitForCoordinator.Register
+     - DeadlockDetector.TrackAndDetect
+   Migration: If you call these methods directly, add a GD.PrintErr (or
+   equivalent) delegate as the errorOutput parameter. Generated code is
+   updated automatically.
+
+
+INTERNAL IMPROVEMENTS
+---------------------
+
+- Extracted ErrorReporterHelper test helper for capturing error output in tests
+- Cleaned up nuget-build.bat to properly clean all project outputs
+
+
 ==================
 v1.4.0 && v1.3.3
 ==================


### PR DESCRIPTION
# v1.4.1

## Bug 修复

- 修复：回调异常的错误信息现在包含 `RequestorType`
- 修复：NuGet 包可能包含旧 DLL，原因是 `GodotSharpDI.csproj` 中的路径引用不正确

## 破坏性变更

### `ErrorReporter` API 重构

- 移除 `Output` / `ErrorOutput` 静态字段
- 移除 `ReportWarning` 方法
- 所有 `Report*` 方法接受 `Exception` 而非 `string exMsg`，新增 `Action<string> errorOutput` 作为最后一个参数
- `BuildServiceNotFoundMessage` / `BuildServiceErrorMessage` 替换为 `ReportServiceNotFound` / `ReportServiceError`
- 新增方法：`ReportParentScopeNotFound`、`ReportWaiterCallbackException`、`ReportResolveDependencyCallbackException`、`ReportError`

### 运行时类方法签名更新

以下运行时类现要求传入 `Action<string> errorOutput` 参数用于错误报告（此前使用 `ErrorReporter` 静态字段）：

- `AsyncProviderRunner.Run`
- `SyncProviderRunner.Run`
- `InjectionExecutor.Execute`
- `WaitForCoordinator.Register`
- `DeadlockDetector.TrackAndDetect`

**迁移方式**：如直接调用这些方法，需添加 `GD.PrintErr`（或等效委托）作为 `errorOutput` 参数。生成代码已自动更新。

## 内部改进

- 提取 `ErrorReporterHelper` 测试辅助类，用于在测试中捕获错误输出
- 清理 `nuget-build.bat`，正确清理所有项目输出